### PR TITLE
handle empty `pre` tags without exception

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -225,6 +225,17 @@ Next line of text";
 		}
 
 		[Fact]
+		public void WhenThereIsEmptyPreTag_ThenConvertToMarkdownPre()
+		{
+			const string html = @"This text has pre tag content <pre><br/ ></pre>Next line of text";
+			const string expected = @"This text has pre tag content 
+
+
+Next line of text";
+			CheckConversion(html, expected);
+		}
+
+		[Fact]
 		public void WhenThereIsUnorderedList_ThenConvertToMarkdownList()
 		{
 			const string html = @"This text has unordered list.<ul><li>Item1</li><li>Item2</li></ul>";

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -167,6 +167,17 @@ This line appears after break.";
 		}
 
 		[Fact]
+		public void WhenThereIsEmptyBlockquoteTag_ThenConvertToMarkdownBlockquote()
+		{
+			const string html = @"This text has <blockquote></blockquote>. This text appear after header.";
+			const string expected = @"This text has 
+
+
+. This text appear after header.";
+			CheckConversion(html, expected);
+		}
+
+		[Fact]
 		public void WhenThereIsParagraphTag_ThenConvertToMarkdownDoubleLineBreakBeforeAndAfter()
 		{
 			const string html = @"This text has markup <p>paragraph.</p> Next line of text";

--- a/src/ReverseMarkdown/Converters/Blockquote.cs
+++ b/src/ReverseMarkdown/Converters/Blockquote.cs
@@ -23,7 +23,7 @@ namespace ReverseMarkdown.Converters
 			var lines = content.ReadLines().Select(item => "> " + item + Environment.NewLine);
 
 			// join all the lines to a single line
-			var result = lines.Aggregate((curr, next) => curr + next);
+			var result = lines.Aggregate(string.Empty, (curr, next) => curr + next);
 
 			return Environment.NewLine + Environment.NewLine + result + Environment.NewLine;
 		}

--- a/src/ReverseMarkdown/Converters/Pre.cs
+++ b/src/ReverseMarkdown/Converters/Pre.cs
@@ -29,7 +29,7 @@ namespace ReverseMarkdown.Converters
 				var lines = node.InnerText.ReadLines().Select(item => "    " + item + Environment.NewLine);
 
 				// join all the lines to a single line
-				var result = lines.Aggregate((curr, next) => curr + next);
+				var result = lines.Aggregate(string.Empty, (curr, next) => curr + next);
 
 				return Environment.NewLine + Environment.NewLine + result + Environment.NewLine;
 			}


### PR DESCRIPTION
Try this test string:
`<pre><br/></pre>`

The `Aggregate` Linq function in the Pre Converter doesn't handle empty sequences and it throws an `InvalidOperationException`.  Fortunately (thanks [StackOverflow](http://stackoverflow.com/a/14897171)!), there's [an overload](http://msdn.microsoft.com/en-us/library/bb548744.aspx) that takes a seed, so we can pass in `string.Empty` and it won't throw that error.

Fiddle :violin: showing the difference: [https://dotnetfiddle.net/tUkhXk](https://dotnetfiddle.net/tUkhXk)

Another option would be to use `string.Join` [[MSDN](https://msdn.microsoft.com/en-us/library/57a79xd0(v=vs.110).aspx)].