### PR TITLE
Add support for <aside> tag

### DIFF
--- a/src/ReverseMarkdown/Converters/Aside.cs
+++ b/src/ReverseMarkdown/Converters/Aside.cs
@@ -1,0 +1,22 @@
+
+using System;
+
+using HtmlAgilityPack;
+
+namespace ReverseMarkdown.Converters
+{
+	public class Aside
+		: ConverterBase
+	{
+		public Aside(Converter converter)
+			: base(converter)
+		{
+			this.Converter.Register("aside", this);
+		}
+
+		public override string Convert(HtmlNode node)
+		{
+			return Environment.NewLine + this.TreatChildren(node).Trim() + Environment.NewLine;
+		}
+	}
+}


### PR DESCRIPTION
Hi there, 

Recently started using this project from nuget, and whilst it worked for the most part, I noticed that it did not support the `<aside>` tag.

Tested locally and I am now getting the desired results, figured I should share back upstream! (Not a lot of work, I just copied the `div` class and renamed it 😉 )

Output Before:
![image](https://user-images.githubusercontent.com/1998970/29517625-de55f4cc-866d-11e7-9ebf-396f9c0c3dc8.png)

Output After:
![image](https://user-images.githubusercontent.com/1998970/29517637-ea72640c-866d-11e7-9f97-67ab7da94f1d.png)


