### PR TITLE
Switch to non-forked HtmlAgilityPack

### DIFF
--- a/src/ReverseMarkdown/ReverseMarkdown.csproj
+++ b/src/ReverseMarkdown/ReverseMarkdown.csproj
@@ -11,6 +11,6 @@
     <PackageLicenseUrl>https://github.com/mysticmind/reversemarkdown-net/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MysticMind.HtmlAgilityPack" Version="1.4.9.4" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.5.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
As title.

Original repo appears to now be compatible with .NET Core, and will stop conflicts with the namespace when using other Nuget packages that rely on HtmlAgilityPack