### PR TITLE
Use enum for the unknown tags config option

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -284,7 +284,7 @@ namespace ReverseMarkdown.Test
         {
             const string html = @"<unknown-tag>text in unknown tag</unknown-tag>";
             const string expected = "text in unknown tag";
-            var config = new Config("bypass");
+            var config = new Config(Config.UnknownTagsOption.Bypass);
             var converter = new Converter(config);
             var result = converter.Convert(html);
             Assert.Equal<string>(expected, result);
@@ -295,7 +295,7 @@ namespace ReverseMarkdown.Test
         {
             const string html = @"<unknown-tag>text in unknown tag</unknown-tag><p>paragraph text</p>";
             string expected = $"{Environment.NewLine}{Environment.NewLine}paragraph text{Environment.NewLine}{Environment.NewLine}";
-            var config = new Config("drop");
+            var config = new Config(Config.UnknownTagsOption.Drop);
             var converter = new Converter(config);
             var result = converter.Convert(html);
             Assert.Equal<string>(expected, result);
@@ -306,7 +306,7 @@ namespace ReverseMarkdown.Test
         {
             const string html = @"<unknown-tag>text in unknown tag</unknown-tag><p>paragraph text</p>";
             string expected = $"<unknown-tag>text in unknown tag</unknown-tag>{Environment.NewLine}{Environment.NewLine}paragraph text{Environment.NewLine}{Environment.NewLine}";
-            var config = new Config("pass_through");
+            var config = new Config(Config.UnknownTagsOption.PassThrough);
             var converter = new Converter(config);
             var result = converter.Convert(html);
             Assert.Equal<string>(expected, result);
@@ -316,23 +316,23 @@ namespace ReverseMarkdown.Test
         public void Check_Converter_With_Unknown_Tag_Raise_Option()
         {
             const string html = @"<unknown-tag>text in unknown tag</unknown-tag><p>paragraph text</p>";
-            var config = new Config("raise");
+            var config = new Config(Config.UnknownTagsOption.Raise);
             var converter = new Converter(config);
             Exception ex = Assert.Throws<UnknownTagException>(() => converter.Convert(html));
             Assert.Equal("Unknown tag: unknown-tag", ex.Message);
         }
 
-        [Fact]
-        public void Check_Converter_With_UnknownTags_Invalid_Option_Value()
-        {
-            var config = new Config("invalid_option");
-            Exception ex = Assert.Throws<InvalidConfigurationException>(() => new Converter(config));
-            Assert.Equal("Invalid UnknownTags config: valid values are pass_through,drop,bypass,raise", ex.Message);
-        }
+        //[Fact]
+        //public void Check_Converter_With_UnknownTags_Invalid_Option_Value()
+        //{
+        //    var config = new Config("invalid_option");
+        //    Exception ex = Assert.Throws<InvalidConfigurationException>(() => new Converter(config));
+        //    Assert.Equal("Invalid UnknownTags config: valid values are pass_through,drop,bypass,raise", ex.Message);
+        //}
 
         private static void CheckConversion(string html, string expected)
 		{
-            var config = new Config("drop");
+            var config = new Config(Config.UnknownTagsOption.Drop);
 			var converter = new Converter();
 			var result = converter.Convert(html);
 			Assert.Equal<string>(expected, result);

--- a/src/ReverseMarkdown/Config.cs
+++ b/src/ReverseMarkdown/Config.cs
@@ -3,20 +3,20 @@ namespace ReverseMarkdown
 {
 	public class Config
 	{
-		private string _unknownTags = "pass_through";
+		private UnknownTagsOption _unknownTags = UnknownTagsOption.PassThrough;
 		private bool _githubFlavored = false;
 		
 		public Config()
 		{
 		}
 
-		public Config(string unknownTags="pass_through", bool githubFlavored=false)
+		public Config(UnknownTagsOption unknownTags=UnknownTagsOption.PassThrough, bool githubFlavored=false)
 		{
 			this._unknownTags = unknownTags;
 			this._githubFlavored = githubFlavored;
 		}
 
-		public string UnknownTags
+		public UnknownTagsOption UnknownTags
 		{
 			get { return this._unknownTags; }
 		}
@@ -25,5 +25,13 @@ namespace ReverseMarkdown
 		{
 			get { return this._githubFlavored; }
 		}
+
+        public enum UnknownTagsOption
+        {
+            PassThrough,
+            Drop,
+            Bypass,
+            Raise
+        }
 	}
 }

--- a/src/ReverseMarkdown/Converter.cs
+++ b/src/ReverseMarkdown/Converter.cs
@@ -25,14 +25,6 @@ namespace ReverseMarkdown
         {
             this._config = config;
 
-            var unknownTagsConfigOptions = new List<string>() { "pass_through", "drop", "bypass", "raise" };
-
-            // check if the passed unknown tags config is valid
-            if (!unknownTagsConfigOptions.Contains(this._config.UnknownTags))
-            {
-                throw new InvalidConfigurationException($"Invalid UnknownTags config: valid values are {string.Join(",", unknownTagsConfigOptions.ToArray())}");
-            }
-
             // instanciate all converters excluding the unknown tags converters
             foreach (Type ctype in typeof(IConverter).GetTypeInfo().Assembly.GetTypes()
                 .Where(t => t.GetTypeInfo().GetInterfaces().Contains(typeof(IConverter)) && 
@@ -90,11 +82,11 @@ namespace ReverseMarkdown
 		{
 			switch (this._config.UnknownTags)
 			{
-				case "pass_through":
+				case Config.UnknownTagsOption.PassThrough:
                     return _passThroughTagsConverter;
-                case "drop":
+                case Config.UnknownTagsOption.Drop:
                     return _dropTagsConverter;
-                case "bypass":
+                case Config.UnknownTagsOption.Bypass:
 					return _byPassTagsConverter;
 				default:
                     throw new UnknownTagException(tagName);


### PR DESCRIPTION
Changed to use an enum for the unknown tags config option to make it easier to use and less complicated.