### PR TITLE
Fixing issue with miscounting headers ('th') in UnderlineFor

### DIFF
--- a/src/ReverseMarkdown/Converters/Tr.cs
+++ b/src/ReverseMarkdown/Converters/Tr.cs
@@ -32,7 +32,7 @@ namespace ReverseMarkdown.Converters
 
 		private string UnderlineFor(HtmlNode node)
 		{
-			int colCount = node.ChildNodes.Count();
+			int colCount = node.ChildNodes.Where(child => child.Name.Contains("th")).Count();
 
 			List<string> cols = new List<string>();
 


### PR DESCRIPTION
While using this nuget package, I ran into some issues with parsing tables, where it would make far to many underlines for the header. I wrote something to improve the accuracy of the parser. 