### PR TITLE
Introduce new options: HrefHandling (Smart) and WhitelistUriSchemes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,36 @@ string result = converter.Convert(html);
 bool githubFlavored = true; // generate GitHub flasvoured markdown, supported for BR, PRE and table tags
 bool removeComments = true; // will ignore all comments
 var config = new ReverseMarkdown.Config(UnknownTagsOption.PassThrough, 
-                githubFlavoured:githubFlavoured, removeComments:removeComments);
+                githubFlavoured:githubFlavoured, removeComments:removeComments) {
+                    new Config() {
+                        HrefHandling = Config.HrefHandlingOption.Smart,
+                        WhitelistUriSchemes = new string[] {"http", "https", "ftp", "ftps", "file"}
+                    }
+
+                };
 var converter = new ReverseMarkdown.Converter(config);
 ```
 
-### UnknownTags config - how to handle unknown tags. 
-Valid options are:
-* `UnknownTagsOption.PassThrough` - Include the unknown tag completely into the result. This is the default
-* `UnknownTagsOption.Drop` - Drop the unknown tag and its content
-* `UnknownTagsOption.Bypass` - Ignore the unknown tag but try to convert its content
-* `UnknownTagsOption.Raise` - Raise an error to let you know
+## Configuration options
+* `GithubFlavored` - Github style markdown for br, pre and table. Default is false
+* `RemoveComments` - Remove comment tags with text. Default is true
+* `BarePlaintext` - Convert to bare plaintext, not markdown. Default is false
+* `CompressNewlines` - Cleans output so that it doesn't contain double newline characters. Default is true
+* `HrefHandling` - how to handle `<a>` tag href attribute
+  * `None` - Outputs `[{name}]({href}{title})` even if name and href is identical. This is the default option.
+  * `Smart` - If name and href equals, outputs just the name instead of `[{name}]({href}{title})`. Note that if Uri is not well formed as per [`Uri.IsWellFormedUriString`](https://docs.microsoft.com/en-us/dotnet/api/system.uri.iswellformeduristring) (i.e string is not correctly escaped like `http://example.com/path/file name.docx`) then markdown syntax will be used anyway.
+               
+    If `href` contains `http/https` protocol, and `name` doesn't but otherwise are the same, output `href` only
+    
+    If `tel:` or `mailto:` scheme, but afterwards identical with name, output `name` only.
+* `UnknownTags` - how to handle unknown tags. 
+  * `UnknownTagsOption.PassThrough` - Include the unknown tag completely into the result. That is, the tag along with the text will be left in output. This is the default
+  * `UnknownTagsOption.Drop` - Drop the unknown tag and its content
+  * `UnknownTagsOption.Bypass` - Ignore the unknown tag but try to convert its content
+  * `UnknownTagsOption.Raise` - Raise an error to let you know
+* `WhitelistUriSchemes` - Specify which schemes (without trailing colon) are to be allowed for `<a>` and `<img>` tags. Others will be bypassed (output text or nothing). By default allows everything.
+
+  If `string.Empty` provided and when `href` schema coudn't be determined - whitelists
 
 > Note that UnknownTags config has been changed to an enumeration in v2.0.0 (breaking change)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var converter = new ReverseMarkdown.Converter(config);
 
 ## Configuration options
 * `GithubFlavored` - Github style markdown for br, pre and table. Default is false
-* `RemoveComments` - Remove comment tags with text. Default is true
+* `RemoveComments` - Remove comment tags with text. Default is false
 * `SmartHrefHandling` - how to handle `<a>` tag href attribute
   * `false` - Outputs `[{name}]({href}{title})` even if name and href is identical. This is the default option.
   * `true` - If name and href equals, outputs just the `name`. Note that if Uri is not well formed as per [`Uri.IsWellFormedUriString`](https://docs.microsoft.com/en-us/dotnet/api/system.uri.iswellformeduristring) (i.e string is not correctly escaped like `http://example.com/path/file name.docx`) then markdown syntax will be used anyway.

--- a/README.md
+++ b/README.md
@@ -24,25 +24,20 @@ string result = converter.Convert(html);
 // with config
 bool githubFlavored = true; // generate GitHub flasvoured markdown, supported for BR, PRE and table tags
 bool removeComments = true; // will ignore all comments
-var config = new ReverseMarkdown.Config(UnknownTagsOption.PassThrough, 
-                githubFlavoured:githubFlavoured, removeComments:removeComments) {
-                    new Config() {
-                        HrefHandling = Config.HrefHandlingOption.Smart,
-                        WhitelistUriSchemes = new string[] {"http", "https", "ftp", "ftps", "file"}
-                    }
-
-                };
+bool smartHrefHandling = true; // remove markdown output for links where appropriate
+var config = new ReverseMarkdown.Config(Config.UnknownTagsOption.PassThrough,
+                githubFlavored: githubFlavored, removeComments: removeComments) {
+                    SmartHrefHandling = smartHrefHandling
+            };
 var converter = new ReverseMarkdown.Converter(config);
 ```
 
 ## Configuration options
 * `GithubFlavored` - Github style markdown for br, pre and table. Default is false
 * `RemoveComments` - Remove comment tags with text. Default is true
-* `BarePlaintext` - Convert to bare plaintext, not markdown. Default is false
-* `CompressNewlines` - Cleans output so that it doesn't contain double newline characters. Default is true
-* `HrefHandling` - how to handle `<a>` tag href attribute
-  * `None` - Outputs `[{name}]({href}{title})` even if name and href is identical. This is the default option.
-  * `Smart` - If name and href equals, outputs just the name instead of `[{name}]({href}{title})`. Note that if Uri is not well formed as per [`Uri.IsWellFormedUriString`](https://docs.microsoft.com/en-us/dotnet/api/system.uri.iswellformeduristring) (i.e string is not correctly escaped like `http://example.com/path/file name.docx`) then markdown syntax will be used anyway.
+* `SmartHrefHandling` - how to handle `<a>` tag href attribute
+  * `false` - Outputs `[{name}]({href}{title})` even if name and href is identical. This is the default option.
+  * `true` - If name and href equals, outputs just the `name`. Note that if Uri is not well formed as per [`Uri.IsWellFormedUriString`](https://docs.microsoft.com/en-us/dotnet/api/system.uri.iswellformeduristring) (i.e string is not correctly escaped like `http://example.com/path/file name.docx`) then markdown syntax will be used anyway.
                
     If `href` contains `http/https` protocol, and `name` doesn't but otherwise are the same, output `href` only
     

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ var converter = new ReverseMarkdown.Converter(config);
   * `UnknownTagsOption.Raise` - Raise an error to let you know
 * `WhitelistUriSchemes` - Specify which schemes (without trailing colon) are to be allowed for `<a>` and `<img>` tags. Others will be bypassed (output text or nothing). By default allows everything.
 
-  If `string.Empty` provided and when `href` schema coudn't be determined - whitelists
+  If `string.Empty` provided and when `href` or `src` schema coudn't be determined - whitelists
+  
+  Schema is determined by `Uri` class, with exception when url begins with `/` (file schema) and `//` (http schema)
 
 > Note that UnknownTags config has been changed to an enumeration in v2.0.0 (breaking change)
 

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using Xunit;
 
 namespace ReverseMarkdown.Test
@@ -426,12 +428,34 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
-        public void WhenThereIsImgTagWithRelativeUrl_ConfitHasWhitelist_ThenConvertToMarkdown() {
+        public void WhenThereIsImgTagWithRelativeUrl_NotWhitelisted_ThenConvertToMarkdown() {
+            CheckConversion(
+                html: @"<img src=""/example.gif""/>",
+                expected: @"",
+                config: new Config() {
+                    WhitelistUriSchemes = new[] { "data" }
+                }
+            );
+        }
+
+        [Fact]
+        public void WhenThereIsImgTagWithUnixUrl_ConfigHasWhitelist_ThenConvertToMarkdown() {
             CheckConversion(
                 html: @"<img src=""/example.gif""/>",
                 expected: @"![](/example.gif)",
                 config: new Config() {
-                    WhitelistUriSchemes = new[] { "data" }
+                    WhitelistUriSchemes = new[] { "file" }
+                }
+            );
+        }
+
+        [Fact]
+        public void WhenThereIsImgTagWithHttpProtocolRelativeUrl_ConfigHasWhitelist_ThenConvertToMarkdown() {
+            CheckConversion(
+                html: @"<img src=""//example.gif""/>",
+                expected: @"![](//example.gif)",
+                config: new Config() {
+                    WhitelistUriSchemes = new[] { "http" }
                 }
             );
         }
@@ -634,6 +658,8 @@ namespace ReverseMarkdown.Test
             var result = converter.Convert(html);
             Assert.Equal(expected, result);
         }
+
+
 
         private static void CheckConversion(string html, string expected, Config config = null) {
             config = config ?? new Config();

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 using Xunit;
 
 namespace ReverseMarkdown.Test
@@ -76,7 +74,7 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""//example.com"">example.com</a>",
                 expected: @"[example.com](//example.com)",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
                 }
             );
         }
@@ -88,7 +86,7 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""https://example.com"">Something intact</a>",
                 expected: @"[Something intact](https://example.com)",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
                 }
             );
         }
@@ -99,7 +97,7 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""http://example.com/abc?x"">http://example.com/abc?x</a>",
                 expected: @"http://example.com/abc?x",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
                 }
             );
         }
@@ -110,7 +108,7 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""http://example.com"">example.com</a>",
                 expected: @"http://example.com",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
                 }
             );
 
@@ -118,7 +116,7 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""https://example.com"">example.com</a>",
                 expected: @"https://example.com",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
                 }
             );
         }
@@ -129,7 +127,7 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""mailto:george@example.com"">george@example.com</a>",
                 expected: @"george@example.com",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
                 }
             );
         }
@@ -140,7 +138,7 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""tel:+1123-45678"">+1123-45678</a>",
                 expected: @"+1123-45678",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
                 }
             );
         }
@@ -151,14 +149,14 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""http://example.com"">example.com</a>",
                 expected: @"http://example.com",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
                 }
             );
             CheckConversion(
                     html: @"<a href=""https://example.com"">example.com</a>",
                     expected: @"https://example.com",
                     config: new Config() {
-                        HrefHandling = Config.HrefHandlingOption.Smart
+                        SmartHrefHandling =  true
                     }
             );
         }
@@ -170,28 +168,28 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""http://example.com/path/file name.docx"">http://example.com/path/file name.docx</a>",
                 expected: @"[http://example.com/path/file name.docx](http://example.com/path/file name.docx)",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
             });
             //The string is an absolute Uri that represents an implicit file Uri.	
             CheckConversion(
                 html: @"<a href=""c:\\directory\filename"">	c:\\directory\filename</a>",
                 expected: @"[c:\\directory\filename](c:\\directory\filename)",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
             });
             //The string is an absolute URI that is missing a slash before the path.	
             CheckConversion(
                 html: @"<a href=""file://c:/directory/filename"">file://c:/directory/filename</a>",
                 expected: @"[file://c:/directory/filename](file://c:/directory/filename)",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
             });
             //The string contains unescaped backslashes even if they are treated as forward slashes.	
             CheckConversion(
                 html: @"<a href=""http:\\host/path/file"">http:\\host/path/file</a>",
                 expected: @"[http:\\host/path/file](http:\\host/path/file)",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
             });
         }
 
@@ -202,7 +200,7 @@ namespace ReverseMarkdown.Test
                 html: @"<a href=""ftp://example.com"">example.com</a>",
                 expected: @"[example.com](ftp://example.com)",
                 config: new Config() {
-                    HrefHandling = Config.HrefHandlingOption.Smart
+                    SmartHrefHandling =  true
                 }
             );
         }
@@ -658,8 +656,6 @@ namespace ReverseMarkdown.Test
             var result = converter.Convert(html);
             Assert.Equal(expected, result);
         }
-
-
 
         private static void CheckConversion(string html, string expected, Config config = null) {
             config = config ?? new Config();

--- a/src/ReverseMarkdown/Config.cs
+++ b/src/ReverseMarkdown/Config.cs
@@ -17,6 +17,7 @@ namespace ReverseMarkdown
             RemoveComments = removeComments;
         }
 
+
         public UnknownTagsOption UnknownTags { get; } = UnknownTagsOption.PassThrough;
 
         public bool GithubFlavored { get; }
@@ -25,12 +26,19 @@ namespace ReverseMarkdown
 
 
         /// <summary>
-        /// Specify which schemes (without trailing colon) are to be allowed for <a> and <img> tags. Others will be bypassed. By default allows everything.
+        /// Specify which schemes (without trailing colon) are to be allowed for &lt;a&gt; and &lt;img&gt; tags. Others will be bypassed. By default allows everything.
         /// <para>If <see cref="string.Empty" /> provided and when href schema coudn't be determined - whitelists</para>
         /// </summary>
         public string[] WhitelistUriSchemes { get; set; }
 
-        public HrefHandlingOption HrefHandling { get; set; } = HrefHandlingOption.None;
+        /// <summary>
+        /// How to handle &lt;a&gt; tag href attribute
+        /// <para>false - Outputs [{name}]({href}{title}) even if name and href is identical. This is the default option.</para>
+        /// true - If name and href equals, outputs just the `name`. Note that if Uri is not well formed as per <see cref="Uri.IsWellFormedUriString"/> (i.e string is not correctly escaped like `http://example.com/path/file name.docx`) then markdown syntax will be used anyway.
+        /// <para>If href contains http/https protocol, and name doesn't but otherwise are the same, output href only</para>
+        /// If tel: or mailto: scheme, but afterwards identical with name, output name only. 
+        /// </summary>
+        public bool SmartHrefHandling { get; set; } = false;
 
         public enum UnknownTagsOption
         {

--- a/src/ReverseMarkdown/Config.cs
+++ b/src/ReverseMarkdown/Config.cs
@@ -60,18 +60,19 @@ namespace ReverseMarkdown
             /// <summary>
             /// If name and href equals, outputs just the name instead of [{name}]({href}{title}). Note that if Uri is not well formed (string is not correctly escaped like http://example.com/path/file name.docx) then markdown syntax will be used anyway.
             /// <para>If href contains http/https protocol, and name doesn't but otherwise are the same, output href only</para>
-            /// If tel: or mailto: scheme, but afterwards identical with name, output name only.
+            /// If tel: or mailto: url, but afterwards identical with name, output name only.
             /// </summary>
             Smart
         }
 
+
         /// <summary>
-        /// Determines whether scheme is allowed: WhitelistUriSchemes contains no elements or contains passed scheme.
+        /// Determines whether url is allowed: WhitelistUriSchemes contains no elements or contains passed url.
         /// </summary>
-        /// <param name="scheme">Scheme name with or without colon</param>
-        internal bool IsSchemeAllowed(string scheme) {
+        /// <param name="url">Scheme name without trailing colon</param>
+        internal bool IsSchemeWhitelisted(string scheme) {
             if (scheme == null) throw new ArgumentNullException(nameof(scheme));
-            var isSchemeAllowed = WhitelistUriSchemes == null || WhitelistUriSchemes.Length == 0 || WhitelistUriSchemes.Contains(scheme.TrimEnd(':'), StringComparer.OrdinalIgnoreCase);
+            var isSchemeAllowed = WhitelistUriSchemes == null || WhitelistUriSchemes.Length == 0 || WhitelistUriSchemes.Contains(scheme, StringComparer.OrdinalIgnoreCase);
             return isSchemeAllowed;
         }
     }

--- a/src/ReverseMarkdown/Config.cs
+++ b/src/ReverseMarkdown/Config.cs
@@ -1,4 +1,8 @@
-﻿namespace ReverseMarkdown
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace ReverseMarkdown
 {
     public class Config
     {
@@ -19,12 +23,56 @@
 
         public bool RemoveComments { get; }
 
+
+        /// <summary>
+        /// Specify which schemes (without trailing colon) are to be allowed for <a> and <img> tags. Others will be bypassed. By default allows everything.
+        /// <para>If <see cref="string.Empty" /> provided and when href schema coudn't be determined - whitelists</para>
+        /// </summary>
+        public string[] WhitelistUriSchemes { get; set; }
+
+        public HrefHandlingOption HrefHandling { get; set; } = HrefHandlingOption.None;
+
         public enum UnknownTagsOption
         {
+            /// <summary>
+            /// Include the unknown tag completely into the result. That is, the tag along with the text will be left in output.
+            /// </summary>
             PassThrough,
+            /// <summary>
+            ///  Drop the unknown tag and its content
+            /// </summary>
             Drop,
+            /// <summary>
+            /// Ignore the unknown tag but try to convert its content
+            /// </summary>
             Bypass,
+            /// <summary>
+            /// Raise an error to let you know
+            /// </summary>
             Raise
+        }
+
+        public enum HrefHandlingOption {
+            /// <summary>
+            /// Outputs [{name}]({href}{title}) even if name and href is identical. This is the default option.
+            /// </summary>
+            None,
+            /// <summary>
+            /// If name and href equals, outputs just the name instead of [{name}]({href}{title}). Note that if Uri is not well formed (string is not correctly escaped like http://example.com/path/file name.docx) then markdown syntax will be used anyway.
+            /// <para>If href contains http/https protocol, and name doesn't but otherwise are the same, output href only</para>
+            /// If tel: or mailto: scheme, but afterwards identical with name, output name only.
+            /// </summary>
+            Smart
+        }
+
+        /// <summary>
+        /// Determines whether scheme is allowed: WhitelistUriSchemes contains no elements or contains passed scheme.
+        /// </summary>
+        /// <param name="scheme">Scheme name with or without colon</param>
+        internal bool IsSchemeAllowed(string scheme) {
+            if (scheme == null) throw new ArgumentNullException(nameof(scheme));
+            var isSchemeAllowed = WhitelistUriSchemes == null || WhitelistUriSchemes.Length == 0 || WhitelistUriSchemes.Contains(scheme.TrimEnd(':'), StringComparer.OrdinalIgnoreCase);
+            return isSchemeAllowed;
         }
     }
 }

--- a/src/ReverseMarkdown/Converters/A.cs
+++ b/src/ReverseMarkdown/Converters/A.cs
@@ -19,7 +19,7 @@ namespace ReverseMarkdown.Converters {
             title = title.Length > 0 ? $" \"{title}\"" : "";
             var scheme = LinkParser.GetScheme(href);
             
-            var isRemoveLinkWhenSameName = Converter.Config.HrefHandling == Config.HrefHandlingOption.Smart
+            var isRemoveLinkWhenSameName = Converter.Config.SmartHrefHandling
                                            && scheme != string.Empty
                                            && Uri.IsWellFormedUriString(href, UriKind.RelativeOrAbsolute)
                                            && (
@@ -37,7 +37,7 @@ namespace ReverseMarkdown.Converters {
 				return name;
 			}
 			else {
-                var useHrefWithHttpWhenNameHasNoScheme = Converter.Config.HrefHandling == Config.HrefHandlingOption.Smart &&
+                var useHrefWithHttpWhenNameHasNoScheme = Converter.Config.SmartHrefHandling &&
                                                         (scheme.Equals("http", StringComparison.OrdinalIgnoreCase) || scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
                                                         && string.Equals(href, $"{scheme}://{name}", StringComparison.OrdinalIgnoreCase);
 

--- a/src/ReverseMarkdown/Converters/A.cs
+++ b/src/ReverseMarkdown/Converters/A.cs
@@ -17,11 +17,7 @@ namespace ReverseMarkdown.Converters {
             var href = node.GetAttributeValue("href", string.Empty).Trim();
             var title = ExtractTitle(node);
             title = title.Length > 0 ? $" \"{title}\"" : "";
-            var scheme = "";
-            try {
-                scheme = (new Uri(href, UriKind.Absolute)).Scheme;
-            }
-            catch { /* Couldn't determine protocol for relative URI */ }
+            var scheme = LinkParser.GetScheme(href);
             
             var isRemoveLinkWhenSameName = Converter.Config.HrefHandling == Config.HrefHandlingOption.Smart
                                            && scheme != string.Empty

--- a/src/ReverseMarkdown/Converters/A.cs
+++ b/src/ReverseMarkdown/Converters/A.cs
@@ -29,7 +29,7 @@ namespace ReverseMarkdown.Converters {
                                             );
 
             if (href.StartsWith("#") //anchor link
-                || !Converter.Config.IsSchemeAllowed(scheme) //Not allowed scheme
+                || !Converter.Config.IsSchemeWhitelisted(scheme) //Not allowed scheme
                 || isRemoveLinkWhenSameName //Same link - why bother with [](). Except when incorrectly escaped, i.e unescaped spaces - then bother with []()
                 || string.IsNullOrEmpty(href) //We would otherwise print empty () here...
                 || string.IsNullOrEmpty(name))

--- a/src/ReverseMarkdown/Converters/Img.cs
+++ b/src/ReverseMarkdown/Converters/Img.cs
@@ -1,7 +1,7 @@
 ﻿using HtmlAgilityPack;
+using System;
 
-namespace ReverseMarkdown.Converters
-{
+namespace ReverseMarkdown.Converters {
     public class Img : ConverterBase
     {
         public Img(Converter converter) : base(converter)
@@ -9,12 +9,23 @@ namespace ReverseMarkdown.Converters
             Converter.Register("img", this);
         }
 
-        public override string Convert(HtmlNode node)
-        {
-            var alt = node.GetAttributeValue("alt", string.Empty);
-            var src = node.GetAttributeValue("src", string.Empty);
-            var title = ExtractTitle(node);
+		public override string Convert(HtmlNode node)
+		{
+			string alt = node.GetAttributeValue("alt", string.Empty);
+			string src = node.GetAttributeValue("src", string.Empty);
 
+            var scheme = "";
+            bool isRelativeUrl = false;
+            try {
+                scheme = (new Uri(src, UriKind.Absolute)).Scheme;
+            }
+            catch {
+                isRelativeUrl = true;
+            }
+
+            if (!isRelativeUrl && !Converter.Config.IsSchemeAllowed(scheme)) { return ""; }
+
+            string title = this.ExtractTitle(node);
             title = title.Length > 0 ? $" \"{title}\"" : "";
 
             return $"![{alt}]({src}{title})";

--- a/src/ReverseMarkdown/Converters/Img.cs
+++ b/src/ReverseMarkdown/Converters/Img.cs
@@ -1,5 +1,6 @@
 ﻿using HtmlAgilityPack;
 using System;
+using System.Text.RegularExpressions;
 
 namespace ReverseMarkdown.Converters {
     public class Img : ConverterBase
@@ -14,16 +15,7 @@ namespace ReverseMarkdown.Converters {
 			string alt = node.GetAttributeValue("alt", string.Empty);
 			string src = node.GetAttributeValue("src", string.Empty);
 
-            var scheme = "";
-            bool isRelativeUrl = false;
-            try {
-                scheme = (new Uri(src, UriKind.Absolute)).Scheme;
-            }
-            catch {
-                isRelativeUrl = true;
-            }
-
-            if (!isRelativeUrl && !Converter.Config.IsSchemeAllowed(scheme)) { return ""; }
+            if (!Converter.Config.IsSchemeWhitelisted(LinkParser.GetScheme(src))) { return ""; }
 
             string title = this.ExtractTitle(node);
             title = title.Length > 0 ? $" \"{title}\"" : "";

--- a/src/ReverseMarkdown/LinkParser.cs
+++ b/src/ReverseMarkdown/LinkParser.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace ReverseMarkdown {
+    internal static class LinkParser {
+
+        /// <summary>
+        /// <para>Gets scheme for provided uri string to overcome different behavior between windows/linux. https://github.com/dotnet/corefx/issues/1745</para>
+        /// Assume http for url starting with //
+        /// <para>Assume file for url starting with /</para>
+        /// Otherwise give what <see cref="Uri.Scheme" /> gives us.
+        /// <para>If non parseable by Uri, return empty string. Will never return null</para>
+        /// </summary>
+        /// <returns></returns>
+        internal static string GetScheme(string url) {
+            var isValidUri = Uri.TryCreate(url, UriKind.Absolute, out Uri uri);
+            //IETF RFC 3986 
+            if (Regex.IsMatch(url, "^//[^/]")) {
+                return "http";
+            }
+            //Unix style path
+            else if (Regex.IsMatch(url, "^/[^/]")) {
+                return "file";
+            } 
+            else if (isValidUri) {
+                return uri.Scheme;
+            }
+            else {
+                return String.Empty;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Gives more control over `a` and `img` tags when convert to markdown, when simplify output and when remove output.
See #27 for more info.