### PR TITLE
Escape characters which cause markdown []() links and images to break

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -87,6 +87,31 @@ namespace ReverseMarkdown.Test
             );
         }
 
+        [Fact]
+        public void WhenThereIsHtmlLinkWithDisallowedCharsInChildren_ThenEscapeTextInMarkdown()
+        {
+            CheckConversion(
+                html: @"<a href=""http://example.com"">this ]( might break things</a>",
+                expected: @"[this \]( might break things](http://example.com)",
+                config: new Config()
+                {
+                    SmartHrefHandling = true
+                }
+            );
+        }
+
+        [Fact]
+        public void WhenThereIsHtmlLinkWithParensInHref_ThenEscapeHrefInMarkdown()
+        {
+            CheckConversion(
+                html: @"<a href=""http://example.com?id=foo)bar"">link</a>",
+                expected: @"[link](http://example.com?id=foo%29bar)",
+                config: new Config()
+                {
+                    SmartHrefHandling = true
+                }
+            );
+        }
 
         [Fact]
         public void WhenThereIsHtmlWithProtocolRelativeUrlHrefAndNameNotMatching_SmartHandling_ThenConvertToMarkdown()
@@ -203,7 +228,7 @@ namespace ReverseMarkdown.Test
             //The string is not correctly escaped.	
             CheckConversion(
                 html: @"<a href=""http://example.com/path/file name.docx"">http://example.com/path/file name.docx</a>",
-                expected: @"[http://example.com/path/file name.docx](http://example.com/path/file name.docx)",
+                expected: @"[http://example.com/path/file name.docx](http://example.com/path/file%20name.docx)",
                 config: new Config()
                 {
                     SmartHrefHandling = true
@@ -438,6 +463,24 @@ namespace ReverseMarkdown.Test
             const string html =
                 @"This text has image <img src=""http://test.com/images/test.png""/>. Next line of text";
             const string expected = @"This text has image ![](http://test.com/images/test.png). Next line of text";
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
+        public void WhenThereIsImgTagWithMutlilineAltText_ThenEnsureNoBlankLinesInMarkdownAltText()
+        {
+            string html =
+                $@"This text has image <img alt=""cat{Environment.NewLine}{Environment.NewLine}dog"" src=""http://test.com/images/test.png""/>. Next line of text";
+            string expected = $@"This text has image ![cat{Environment.NewLine}dog](http://test.com/images/test.png). Next line of text";
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
+        public void WhenThereIsImgTagWithBracesInAltText_ThenEnsureAltTextIsEscapedInMarkdown()
+        {
+            string html =
+                $@"This text has image <img alt=""a]b"" src=""http://test.com/images/test.png""/>. Next line of text";
+            string expected = $@"This text has image ![a\]b](http://test.com/images/test.png). Next line of text";
             CheckConversion(html, expected);
         }
 

--- a/src/ReverseMarkdown/Converters/A.cs
+++ b/src/ReverseMarkdown/Converters/A.cs
@@ -14,7 +14,7 @@ namespace ReverseMarkdown.Converters {
         {
             var name = TreatChildren(node).Trim();
 
-            var href = node.GetAttributeValue("href", string.Empty).Trim();
+            var href = node.GetAttributeValue("href", string.Empty).Trim().Replace("(", "%28").Replace(")", "%29").Replace(" ", "%20");
             var title = ExtractTitle(node);
             title = title.Length > 0 ? $" \"{title}\"" : "";
             var scheme = StringUtils.GetScheme(href);
@@ -41,7 +41,7 @@ namespace ReverseMarkdown.Converters {
                                                         (scheme.Equals("http", StringComparison.OrdinalIgnoreCase) || scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
                                                         && string.Equals(href, $"{scheme}://{name}", StringComparison.OrdinalIgnoreCase);
 
-                return useHrefWithHttpWhenNameHasNoScheme ? href : $"[{name}]({href}{title})";
+                return useHrefWithHttpWhenNameHasNoScheme ? href : $"[{StringUtils.EscapeLinkText(name)}]({href}{title})";
             }
 		}
 	}

--- a/src/ReverseMarkdown/Converters/Img.cs
+++ b/src/ReverseMarkdown/Converters/Img.cs
@@ -21,7 +21,7 @@ namespace ReverseMarkdown.Converters {
             var title = ExtractTitle(node);
             title = title.Length > 0 ? $" \"{title}\"" : "";
 
-            return $"![{alt}]({src}{title})";
+            return $"![{StringUtils.EscapeLinkText(alt)}]({src}{title})";
         }
     }
 }

--- a/src/ReverseMarkdown/StringUtils.cs
+++ b/src/ReverseMarkdown/StringUtils.cs
@@ -45,5 +45,15 @@ namespace ReverseMarkdown
                 return String.Empty;
             }
         }
+
+        /// <summary>
+        /// Escape/clean characters which would break the [] section of a markdown []() link
+        /// </summary>
+        internal static string EscapeLinkText(string rawText)
+        {
+            return Regex.Replace(rawText, @"\r?\n\s*\r?\n", Environment.NewLine, RegexOptions.Singleline)
+                .Replace("[", @"\[")
+                .Replace("]", @"\]");
+        }
     }
 }


### PR DESCRIPTION
Fixes #38

In a markdown link `[text](href)` or imagee `![text](href)` the `text` should not contain `[` or `]` and the href should not contain `)`, `(` or ` ` (space) because these would terminate the section.

Text is also allowed to have newlines, but not multiple adjacent newlines.

This change just encodes those two fields correctly to escape these characters.

