### PR TITLE
Formatting fixes for HTML which produces broken Markdown

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -672,6 +672,21 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
+        public void WhenListIsInTable_LeaveListAsHtml()
+        {
+            var html =
+                $"<table><tr><th>Heading</th></tr><tr><td><ol><li>Item1</li></ol></td></tr></table>";
+
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| Heading |{Environment.NewLine}";
+            expected += $"| --- |{Environment.NewLine}";
+            expected += $"| <ol><li>Item1</li></ol> |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
         public void Check_Converter_With_Unknown_Tag_ByPass_Option()
         {
             const string html = @"<unknown-tag>text in unknown tag</unknown-tag>";

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -662,6 +662,16 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
+        public void WhenListContainsParagraphsOutsideItems_ConvertToMarkdownAndIndentSiblings()
+        {
+            var html =
+                $"<ol>{Environment.NewLine}\t<li>Item1</li>{Environment.NewLine}\t<p>Item 1 additional info</p>{Environment.NewLine}\t<li>Item2</li>{Environment.NewLine}</ol>";
+            var expected =
+                $"{Environment.NewLine}1. Item1{Environment.NewLine}    Item 1 additional info{Environment.NewLine}2. Item2{Environment.NewLine}{Environment.NewLine}";
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
         public void Check_Converter_With_Unknown_Tag_ByPass_Option()
         {
             const string html = @"<unknown-tag>text in unknown tag</unknown-tag>";

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1008,5 +1008,15 @@ namespace ReverseMarkdown.Test
 
             Assert.Equal(expected, result, StringComparer.OrdinalIgnoreCase);
         }
+ 
+        [Fact]
+        public void When_TextContainsAngleBrackets_HexEscapeAngleBrackets()
+        {
+            string html = @"<p>Value = &lt;Your text here&gt;</p>";
+
+            string expected = $@"{Environment.NewLine}Value = &lt;Your text here&gt;{Environment.NewLine}";
+
+            CheckConversion(html, expected);
+        }
     }
 }

--- a/src/ReverseMarkdown/Converters/Ol.cs
+++ b/src/ReverseMarkdown/Converters/Ol.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Linq;
 using HtmlAgilityPack;
 
 namespace ReverseMarkdown.Converters
@@ -18,7 +18,13 @@ namespace ReverseMarkdown.Converters
 
 		public override string Convert(HtmlNode node)
 		{
-			return $"{Environment.NewLine}{TreatChildren(node)}{Environment.NewLine}";
+            // Lists inside tables are not supported as markdown, so leave as HTML
+            if (node.Ancestors("table").Count() > 0)
+            {
+                return node.OuterHtml;
+            }
+
+            return $"{Environment.NewLine}{TreatChildren(node)}{Environment.NewLine}";
 		}
 	}
 }

--- a/src/ReverseMarkdown/Converters/P.cs
+++ b/src/ReverseMarkdown/Converters/P.cs
@@ -21,7 +21,8 @@ namespace ReverseMarkdown.Converters
         private static string IndentationFor(HtmlNode node)
         {
             var length = node.Ancestors("ol").Count() + node.Ancestors("ul").Count();
-            return node.ParentNode.Name.ToLowerInvariant() == "li" && node.ParentNode.FirstChild != node
+            bool parentIsList = node.ParentNode.Name.ToLowerInvariant() == "li" || node.ParentNode.Name.ToLowerInvariant() == "ol";
+            return parentIsList && node.ParentNode.FirstChild != node
                 ? new string(' ', length * 4)
                 : Environment.NewLine;
         }

--- a/src/ReverseMarkdown/Converters/Text.cs
+++ b/src/ReverseMarkdown/Converters/Text.cs
@@ -24,7 +24,17 @@ namespace ReverseMarkdown.Converters
 
         private string TreatText(HtmlNode node)
         {
-            var content = DecodeHtml(node.InnerText);
+            // Prevent &lt; and &gt; from being converted to < and > as this will be interpreted as HTML by markdown
+            string content = node.InnerText
+                .Replace("&lt;", "%3C")
+                .Replace("&gt;", "%3E");
+
+            content = DecodeHtml(content);
+
+            // Not all renderers support hex encoded characters, so convert back to escaped HTML
+            content = node.InnerText
+                .Replace("%3C", "&lt;")
+                .Replace("%3E", "&gt;");
 
             //strip leading spaces and tabs for text within list item 
             var parent = node.ParentNode;


### PR DESCRIPTION
Various formatting fixes

Fixes #40 - When lists are in tables, leave as html
Fixes #41 - Preserve `&lt;` and `&gt;` in text
Fixes #42 - Fix indent of `<p>` inside `<ol>`