### PR TITLE
Prevent conversion of headings inside tables

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -403,6 +403,15 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
+        public void WhenThereIsHeadingInsideTable_ThenIgnoreHeadingLevel()
+        {
+            string html = $"<table>{Environment.NewLine}<tr><th><h2>Heading <strong>text</strong></h2></th></tr>{Environment.NewLine}<tr><td>Content</td></tr>{Environment.NewLine}</table>";
+            var expected =
+                $"{Environment.NewLine}{Environment.NewLine}| Heading **text** |{Environment.NewLine}| --- |{Environment.NewLine}| Content |{Environment.NewLine}{Environment.NewLine}";
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
         public void WhenThereIsBlockquoteTag_ThenConvertToMarkdownBlockquote()
         {
             const string html = @"This text has <blockquote>blockquote</blockquote>. This text appear after header.";

--- a/src/ReverseMarkdown/Converters/H.cs
+++ b/src/ReverseMarkdown/Converters/H.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using HtmlAgilityPack;
 
 namespace ReverseMarkdown.Converters
@@ -16,6 +17,12 @@ namespace ReverseMarkdown.Converters
 
         public override string Convert(HtmlNode node)
         {
+            // Headings inside tables are not supported as markdown, so just ignore the heading and convert children
+            if (node.Ancestors("table").Count() > 0)
+            {
+                return TreatChildren(node);
+            }
+
             var prefix = new string('#', System.Convert.ToInt32(node.Name.Substring(1)));
 
             return $"{Environment.NewLine}{prefix} {TreatChildren(node)}{Environment.NewLine}";


### PR DESCRIPTION
Fixes #44 

Markdown doesn't support headings inside tables, and there is no good translation, so simply remove the headings.

Text and other formatting inside the heading is still converted.