### PR TITLE
Paragraphs in tables

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -681,7 +681,7 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
-        public void WhenListIsInTable_LeaveListAsHtml()
+        public void When_OrderedListIsInTable_LeaveListAsHtml()
         {
             var html =
                 $"<table><tr><th>Heading</th></tr><tr><td><ol><li>Item1</li></ol></td></tr></table>";
@@ -690,6 +690,21 @@ namespace ReverseMarkdown.Test
             expected += $"| Heading |{Environment.NewLine}";
             expected += $"| --- |{Environment.NewLine}";
             expected += $"| <ol><li>Item1</li></ol> |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
+        public void When_UnorderedListIsInTable_LeaveListAsHtml()
+        {
+            var html =
+                $"<table><tr><th>Heading</th></tr><tr><td><ul><li>Item1</li></ul></td></tr></table>";
+
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| Heading |{Environment.NewLine}";
+            expected += $"| --- |{Environment.NewLine}";
+            expected += $"| <ul><li>Item1</li></ul> |{Environment.NewLine}";
             expected += Environment.NewLine;
 
             CheckConversion(html, expected);

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -844,6 +844,20 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
+        public void WhenTable_CellContainsParagraph_AddBrThenConvertToGFMTable()
+        {
+            var html =
+                $"<table><tr><th>col1</th></tr><tr><td><p>line1</p><p>line2</p></td></tr></table>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| col1 |{Environment.NewLine}";
+            expected += $"| --- |{Environment.NewLine}";
+            expected += $"| line1<br>line2<br> |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
         public void When_BR_With_GitHubFlavored_Config_ThenConvertToGFM_BR()
         {
             const string html = @"First part<br />Second part";

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -866,10 +866,27 @@ namespace ReverseMarkdown.Test
             var expected = $"{Environment.NewLine}{Environment.NewLine}";
             expected += $"| col1 |{Environment.NewLine}";
             expected += $"| --- |{Environment.NewLine}";
-            expected += $"| line1<br>line2<br> |{Environment.NewLine}";
+            expected += $"| line1<br><br>line2<br> |{Environment.NewLine}";
             expected += Environment.NewLine;
 
             CheckConversion(html, expected);
+        }
+
+        [Fact]
+        public void WhenTable_CellContainsBr_PreserveBrAndConvertToGFMTable()
+        {
+            var html =
+                $"<table><tr><th>col1</th></tr><tr><td>line 1<br>line 2</td></tr></table>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| col1 |{Environment.NewLine}";
+            expected += $"| --- |{Environment.NewLine}";
+            expected += $"| line 1<br>line 2 |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected, new Config
+            {
+                GithubFlavored = true,
+            });
         }
 
         [Fact]

--- a/src/ReverseMarkdown/Converters/P.cs
+++ b/src/ReverseMarkdown/Converters/P.cs
@@ -15,16 +15,28 @@ namespace ReverseMarkdown.Converters
         public override string Convert(HtmlNode node)
         {
             var indentation = IndentationFor(node);
-            return $"{indentation}{TreatChildren(node).Trim()}{Environment.NewLine}";
+            var lineEnd = LineEndFor(node);
+            return $"{indentation}{TreatChildren(node).Trim()}{lineEnd}";
         }
 
         private static string IndentationFor(HtmlNode node)
         {
+            if (node.Ancestors("table").Any())
+                return string.Empty;
+
             var length = node.Ancestors("ol").Count() + node.Ancestors("ul").Count();
             bool parentIsList = node.ParentNode.Name.ToLowerInvariant() == "li" || node.ParentNode.Name.ToLowerInvariant() == "ol";
             return parentIsList && node.ParentNode.FirstChild != node
                 ? new string(' ', length * 4)
                 : Environment.NewLine;
+        }
+
+        private static string LineEndFor(HtmlNode node)
+        {
+            if (node.Ancestors("table").Any())
+                return "<br>";
+
+            return Environment.NewLine;
         }
     }
 }

--- a/src/ReverseMarkdown/Converters/P.cs
+++ b/src/ReverseMarkdown/Converters/P.cs
@@ -15,27 +15,22 @@ namespace ReverseMarkdown.Converters
         public override string Convert(HtmlNode node)
         {
             var indentation = IndentationFor(node);
-            var lineEnd = LineEndFor(node);
-            return $"{indentation}{TreatChildren(node).Trim()}{lineEnd}";
+            return $"{indentation}{TreatChildren(node).Trim()}{Environment.NewLine}";
         }
 
         private static string IndentationFor(HtmlNode node)
         {
-            if (node.Ancestors("table").Any())
-                return string.Empty;
-
-            var length = node.Ancestors("ol").Count() + node.Ancestors("ul").Count();
             string parentName = node.ParentNode.Name.ToLowerInvariant();
-            bool parentIsList = parentName == "li" || parentName == "ol" || parentName == "ul";
-            return parentIsList && node.ParentNode.FirstChild != node
-                ? new string(' ', length * 4)
-                : Environment.NewLine;
-        }
 
-        private static string LineEndFor(HtmlNode node)
-        {
-            if (node.Ancestors("table").Any())
-                return "<br>";
+            // If p follows a list item, indent it instead of adding a leading newline
+            var length = node.Ancestors("ol").Count() + node.Ancestors("ul").Count();
+            bool parentIsList = parentName == "li" || parentName == "ol" || parentName == "ul";
+            if (parentIsList && node.ParentNode.FirstChild != node)
+                return new string(' ', length * 4);
+
+            // If p is at the start of a table cell, no leading newline
+            if ((parentName == "td" || parentName == "th") && node.ParentNode.FirstChild == node)
+                return string.Empty;
 
             return Environment.NewLine;
         }

--- a/src/ReverseMarkdown/Converters/P.cs
+++ b/src/ReverseMarkdown/Converters/P.cs
@@ -25,7 +25,8 @@ namespace ReverseMarkdown.Converters
                 return string.Empty;
 
             var length = node.Ancestors("ol").Count() + node.Ancestors("ul").Count();
-            bool parentIsList = node.ParentNode.Name.ToLowerInvariant() == "li" || node.ParentNode.Name.ToLowerInvariant() == "ol";
+            string parentName = node.ParentNode.Name.ToLowerInvariant();
+            bool parentIsList = parentName == "li" || parentName == "ol" || parentName == "ul";
             return parentIsList && node.ParentNode.FirstChild != node
                 ? new string(' ', length * 4)
                 : Environment.NewLine;

--- a/src/ReverseMarkdown/Converters/Td.cs
+++ b/src/ReverseMarkdown/Converters/Td.cs
@@ -1,4 +1,5 @@
 ﻿using HtmlAgilityPack;
+using System;
 
 namespace ReverseMarkdown.Converters
 {
@@ -16,7 +17,9 @@ namespace ReverseMarkdown.Converters
 
         public override string Convert(HtmlNode node)
         {
-            var content = TreatChildren(node);
+            var content = TreatChildren(node)
+                .Replace(Environment.NewLine, "<br>");
+
             return $" {content} |";
         }
     }


### PR DESCRIPTION
Fixes #48 ~~by dropping leading indentation/newline for paragraphs in tables, and replacing trailing newline with `<br>`~~. 
**Update:** Given newlines are never allowed in table cells, I decided it would be safer to just convert newline to `<br>` after the children have been converted. This way conversion logic for other elements doesn't need to have special cases for tables. One exception: I added extra check to paragraph leading newline to prevent blank line at top of table cell, similar to how p in list indent works.
Now also fixes #50.

I also realized my fix for #42 didn't take into account unordered lists (I misread `li` as `ul` 😖), so adding in the same fix for `ul` as well.