### PR TITLE
Don't crash when tables have empty rows

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -890,6 +890,24 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
+        public void WhenTable_HasEmptyRow_DropsEmptyRow()
+        {
+            const string html =
+                @"<table><tr><td>abc</td></tr><tr></tr></table>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| <!----> |{Environment.NewLine}";
+            expected += $"| --- |{Environment.NewLine}";
+            expected += $"| abc |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected, new Config
+            {
+                GithubFlavored = true,
+                TableWithoutHeaderRowHandling = Config.TableWithoutHeaderRowHandlingOption.EmptyRow,
+            });
+        }
+
+        [Fact]
         public void When_BR_With_GitHubFlavored_Config_ThenConvertToGFM_BR()
         {
             const string html = @"First part<br />Second part";

--- a/src/ReverseMarkdown/Converters/Table.cs
+++ b/src/ReverseMarkdown/Converters/Table.cs
@@ -51,8 +51,8 @@ namespace ReverseMarkdown.Converters
                 underlineRowItems.Add("---");
             }
 
-            var headerRow = $"| {headerRowItems.Aggregate((item1, item2) => item1 + " | " + item2)} |{Environment.NewLine}";
-            var underlineRow = $"| {underlineRowItems.Aggregate((item1, item2) => item1 + " | " + item2)} |{Environment.NewLine}";
+            var headerRow = $"| {string.Join(" | ", headerRowItems)} |{Environment.NewLine}";
+            var underlineRow = $"| {string.Join(" | ", underlineRowItems)} |{Environment.NewLine}";
 
             return headerRow + underlineRow;
         }

--- a/src/ReverseMarkdown/Converters/Tr.cs
+++ b/src/ReverseMarkdown/Converters/Tr.cs
@@ -17,6 +17,11 @@ namespace ReverseMarkdown.Converters
         {
             var content = TreatChildren(node).TrimEnd();
             var underline = "";
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return "";
+            }
             
             if (IsTableHeaderRow(node) || UseFirstRowAsHeaderRow(node))
             {
@@ -61,7 +66,7 @@ namespace ReverseMarkdown.Converters
                 cols.Add("---");
             }
 
-            var colsAggregated = cols.Aggregate((item1, item2) => item1 + " | " + item2);
+            var colsAggregated = string.Join(" | ", cols);
 
             return $"| {colsAggregated} |{Environment.NewLine}";
         }


### PR DESCRIPTION
Fixed #53 by replacing `list.Aggregate` with `string.Join` which will return empty string instead of throwing if `list` is empty.

Also choosing to just drop the row if a row is empty. With the option to make first row a heading, this can cause some minor problems in the output if the first row is empty because there is no way to calculate how many columns the table has, but the conversion will proceed and the Markdown is still very readable. This doesn't seem like a case we should optimize for.