### PR TITLE
Minor cleanup of blank lines in nested lists when html has whitespace

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -641,6 +641,34 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
+        public void WhenThereIsWhitespaceAroundNestedLists_PreventBlankLinesWhenConvertingToMarkdownList()
+        {
+            string html = @"
+<ul>
+    <li>OuterItem1
+        <ol>
+            <li>InnerItem1</li>
+        </ol>
+    </li>
+    <li>Item2</li>
+    <ol>
+        <li>InnerItem2</li>
+    </ol>
+    <li>Item3</li>
+</ul>".Trim();
+
+            var expected = @"
+- OuterItem1
+    1. InnerItem1
+- Item2
+    1. InnerItem2
+- Item3
+
+";
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
         public void
             WhenListItemTextContainsLeadingAndTrailingSpacesAndTabs_ThenConvertToMarkdownListItemWithSpacesAndTabsStripped()
         {

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -643,28 +643,14 @@ namespace ReverseMarkdown.Test
         [Fact]
         public void WhenThereIsWhitespaceAroundNestedLists_PreventBlankLinesWhenConvertingToMarkdownList()
         {
-            string html = @"
-<ul>
-    <li>OuterItem1
-        <ol>
-            <li>InnerItem1</li>
-        </ol>
-    </li>
-    <li>Item2</li>
-    <ol>
-        <li>InnerItem2</li>
-    </ol>
-    <li>Item3</li>
-</ul>".Trim();
+            string html = $@"<ul>{Environment.NewLine}    ";
+            html += $@"    <li>OuterItem1{Environment.NewLine}        <ol>{Environment.NewLine}            <li>InnerItem1</li>{Environment.NewLine}        </ol>{Environment.NewLine}    </li>{Environment.NewLine}";
+            html += $@"    <li>Item2</li>{Environment.NewLine}";
+            html += $@"    <ol>{Environment.NewLine}        <li>InnerItem2</li>{Environment.NewLine}    </ol>{Environment.NewLine}";
+            html += $@"    <li>Item3</li>{ Environment.NewLine}";
+            html += $@"</ul>";
 
-            var expected = @"
-- OuterItem1
-    1. InnerItem1
-- Item2
-    1. InnerItem2
-- Item3
-
-";
+            var expected = $@"{Environment.NewLine}- OuterItem1{Environment.NewLine}    1. InnerItem1{Environment.NewLine}- Item2{Environment.NewLine}    1. InnerItem2{Environment.NewLine}- Item3{Environment.NewLine}{Environment.NewLine}";
             CheckConversion(html, expected);
         }
 

--- a/src/ReverseMarkdown/Converters/Li.cs
+++ b/src/ReverseMarkdown/Converters/Li.cs
@@ -14,6 +14,17 @@ namespace ReverseMarkdown.Converters
 
         public override string Convert(HtmlNode node)
         {
+            // Standardize whitespace before inner lists so that the following are equivalent
+            //   <li>Foo<ul><li>...
+            //   <li>Foo\n    <ul><li>...
+            foreach (var innerList in node.SelectNodes("//ul|//ol") ?? Enumerable.Empty<HtmlNode>())
+            {
+                if (innerList.PreviousSibling?.NodeType == HtmlNodeType.Text)
+                {
+                    innerList.PreviousSibling.InnerHtml = innerList.PreviousSibling.InnerHtml.Chomp();
+                }
+            }
+
             var content = TreatChildren(node);
             var indentation = IndentationFor(node);
             var prefix = PrefixFor(node);

--- a/src/ReverseMarkdown/Converters/Ol.cs
+++ b/src/ReverseMarkdown/Converters/Ol.cs
@@ -4,27 +4,36 @@ using HtmlAgilityPack;
 
 namespace ReverseMarkdown.Converters
 {
-	public class Ol : ConverterBase
-	{
-		public Ol(Converter converter) : base(converter)
-		{
-			var elements = new [] { "ol", "ul" };
+    public class Ol : ConverterBase
+    {
+        public Ol(Converter converter) : base(converter)
+        {
+            var elements = new[] { "ol", "ul" };
 
-			foreach (var element in elements)
-			{
-				Converter.Register(element, this);
-			}
-		}
+            foreach (var element in elements)
+            {
+                Converter.Register(element, this);
+            }
+        }
 
-		public override string Convert(HtmlNode node)
-		{
+        public override string Convert(HtmlNode node)
+        {
             // Lists inside tables are not supported as markdown, so leave as HTML
-            if (node.Ancestors("table").Count() > 0)
+            if (node.Ancestors("table").Any())
             {
                 return node.OuterHtml;
             }
 
-            return $"{Environment.NewLine}{TreatChildren(node)}{Environment.NewLine}";
-		}
-	}
+            string prefixSuffix = Environment.NewLine;
+
+            // Prevent blank lines being inserted in nested lists
+            string parentName = node.ParentNode.Name.ToLowerInvariant();
+            if (parentName == "ol" || parentName == "ul")
+            {
+                prefixSuffix = "";
+            }
+
+            return $"{prefixSuffix}{TreatChildren(node)}{prefixSuffix}";
+        }
+    }
 }


### PR DESCRIPTION
Fixes #54 by
- Standardizing whitespace around leading text in an `<li>` when the item also contains an inner list (for `<ol><li><ol>...` case)
- Preventing newlines around lists whose parent is an `<ol>` or `<ul>` (for `<ol><ol>...` case)


_Also adding a very basic `.editorconfig` to stop Visual Studio incorrectly formatting files with tabs. There's lots more things you could add to this config to standardize formatting and conventions if you can be bothered, but tabs v. spaces is particularly obnoxious when mixed._