### PR TITLE
Fix handling of table with thead and td tag (instead of th).

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -886,6 +886,35 @@ namespace ReverseMarkdown.Test
             CheckConversion(html, expected);
         }
 
+
+        [Fact]
+        public void WhenTable_ContainsTheadTh_ConvertToGFMTable() {
+            var html = "<table><thead><tr><th>col1</th><th>col2</th></tr></thead><tbody><tr><td>data1</td><td>data2</td></tr><tbody></table>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| col1 | col2 |{Environment.NewLine}";
+            expected += $"| --- | --- |{Environment.NewLine}";
+            expected += $"| data1 | data2 |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected, new Config {
+                GithubFlavored = true,
+            });
+        }
+
+        [Fact]
+        public void WhenTable_ContainsTheadTd_ConvertToGFMTable() {
+            var html = "<table><thead><tr><td>col1</td><td>col2</td></tr></thead><tbody><tr><td>data1</td><td>data2</td></tr><tbody></table>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| col1 | col2 |{Environment.NewLine}";
+            expected += $"| --- | --- |{Environment.NewLine}";
+            expected += $"| data1 | data2 |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected, new Config {
+                GithubFlavored = true,
+            });
+        }
+
         [Fact]
         public void WhenTable_CellContainsBr_PreserveBrAndConvertToGFMTable()
         {

--- a/src/ReverseMarkdown/Converters/Tr.cs
+++ b/src/ReverseMarkdown/Converters/Tr.cs
@@ -33,8 +33,8 @@ namespace ReverseMarkdown.Converters
 
         private bool UseFirstRowAsHeaderRow(HtmlNode node)
         {
-            var tableNode = node.ParentNode;
-            var firstRow = tableNode.SelectNodes("tr")?.FirstOrDefault();
+            var tableNode = node.Ancestors("table").FirstOrDefault();
+            var firstRow = tableNode?.SelectSingleNode("//tr");
 
             if (firstRow == null)
             {


### PR DESCRIPTION
Real-world scenario when copy/pasting table from MS Word.
Issue https://github.com/mysticmind/reversemarkdown-net/issues/57

Issue introduced probably in mysticmind/reversemarkdown-net@8b535a2707b12abf20157028eea7324fd8955e4d