### PR TITLE
Fix Issue #61: Html from Outlook 2016 not being converted to Markdown

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1027,7 +1027,7 @@ namespace ReverseMarkdown.Test
         {
             const string html =
                 @"Hello there <!-- This is a HTML comment block which will be removed! --><!-- This wont be removed because it is incomplete";
-            const string expected = @"Hello there <!-- This wont be removed because it is incomplete";
+            const string expected = @"Hello there ";
 
             var config = new Config
             {

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1155,7 +1155,7 @@ namespace ReverseMarkdown.Test
             CheckConversion(html, expected);
         }
 
-        [Fact(Skip = "Issue 61. Have to find out a way how to handle unclosed CDATA tags.")]
+        [Fact(Skip = "Issue 61. Unclosed CDATA tags are invalid and HtmlAgilityPack won't parse it correctly. Browsers doesn't parse them correctly too.")]
         public void WhenUnclosedStyleTag_WithBypassUnknownTags_ThenConvertToMarkdown() {
             string html = @"<html><head><style></head><body><p>Test content</p></body></html>";
             string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
@@ -1165,7 +1165,7 @@ namespace ReverseMarkdown.Test
             });
         }
 
-        [Fact(Skip = "Issue 61. Have to find out a way how to handle unclosed CDATA tags.")]
+        [Fact(Skip = "Issue 61. Unclosed CDATA tags are invalid and HtmlAgilityPack won't parse it correctly. Browsers doesn't parse them correctly too.")]
         public void WhenUnclosedScriptTag_WithBypassUnknownTags_ThenConvertToMarkdown() {
             string html = @"<html><body><script><p>Test content</p></body></html>";
             string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1157,7 +1157,6 @@ namespace ReverseMarkdown.Test
 
         [Fact(Skip = "Issue 61. Have to find out a way how to handle unclosed CDATA tags.")]
         public void WhenUnclosedStyleTag_WithBypassUnknownTags_ThenConvertToMarkdown() {
-            // note that the string also has a tab space
             string html = @"<html><head><style></head><body><p>Test content</p></body></html>";
             string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
 
@@ -1168,7 +1167,6 @@ namespace ReverseMarkdown.Test
 
         [Fact(Skip = "Issue 61. Have to find out a way how to handle unclosed CDATA tags.")]
         public void WhenUnclosedScriptTag_WithBypassUnknownTags_ThenConvertToMarkdown() {
-            // note that the string also has a tab space
             string html = @"<html><body><script><p>Test content</p></body></html>";
             string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
 
@@ -1179,7 +1177,6 @@ namespace ReverseMarkdown.Test
 
         [Fact]
         public void WhenCommentOverlapTag_WithRemoveComments_ThenDoNotStripContentBetweenComments() {
-            // note that the string also has a tab space
             string html = @"<p>test <!-- comment -->content<!-- another comment --></p>";
             string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
 

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1154,5 +1154,40 @@ namespace ReverseMarkdown.Test
 
             CheckConversion(html, expected);
         }
+
+        [Fact(Skip = "Issue 61. Have to find out a way how to handle unclosed CDATA tags.")]
+        public void WhenUnclosedStyleTag_WithBypassUnknownTags_ThenConvertToMarkdown() {
+            // note that the string also has a tab space
+            string html = @"<html><head><style></head><body><p>Test content</p></body></html>";
+            string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
+
+            CheckConversion(html, expected, new Config() {
+                UnknownTags = Config.UnknownTagsOption.Bypass
+            });
+        }
+
+        [Fact(Skip = "Issue 61. Have to find out a way how to handle unclosed CDATA tags.")]
+        public void WhenUnclosedScriptTag_WithBypassUnknownTags_ThenConvertToMarkdown() {
+            // note that the string also has a tab space
+            string html = @"<html><body><script><p>Test content</p></body></html>";
+            string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
+
+            CheckConversion(html, expected, new Config() {
+                UnknownTags = Config.UnknownTagsOption.Bypass
+            });
+        }
+
+        [Fact]
+        public void WhenCommentOverlapTag_WithRemoveComments_ThenDoNotStripContentBetweenComments() {
+            // note that the string also has a tab space
+            string html = @"<p>test <!-- comment -->content<!-- another comment --></p>";
+            string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
+
+            CheckConversion(html, expected, new Config() {
+                RemoveComments = true
+            });
+        }
+
+
     }
 }

--- a/src/ReverseMarkdown/Cleaner.cs
+++ b/src/ReverseMarkdown/Cleaner.cs
@@ -17,7 +17,7 @@ namespace ReverseMarkdown
         private static string RemoveComments(string content)
         {
             // optionally remove HTML comment tags from content (i.e `<!-- this is a comment block -->`)
-            content = Regex.Replace(content, @"<!--(\n|.)*-->", "");
+            content = Regex.Replace(content, @"<!--(\n|.)*?-->", "");
             return content;
         }
 

--- a/src/ReverseMarkdown/Cleaner.cs
+++ b/src/ReverseMarkdown/Cleaner.cs
@@ -4,20 +4,13 @@ using System.Text.RegularExpressions;
 
 namespace ReverseMarkdown
 {
-    public class Cleaner
+    public static class Cleaner
     {
         private static string CleanTagBorders(string content)
         {
             // content from some htl editors such as CKEditor emits newline and tab between tags, clean that up
             content = content.Replace("\n\t", "");
             content = content.Replace(Environment.NewLine + "\t", "");
-            return content;
-        }
-
-        private static string RemoveComments(string content)
-        {
-            // optionally remove HTML comment tags from content (i.e `<!-- this is a comment block -->`)
-            content = Regex.Replace(content, @"<!--(\n|.)*?-->", "");
             return content;
         }
 
@@ -32,11 +25,6 @@ namespace ReverseMarkdown
         {
             content = NormalizeSpaceChars(content);
             content = CleanTagBorders(content);
-
-            if (removeComments)
-            {
-                content = RemoveComments(content);
-            }
 
             return content;
         }

--- a/src/ReverseMarkdown/Converters/Drop.cs
+++ b/src/ReverseMarkdown/Converters/Drop.cs
@@ -6,6 +6,9 @@ namespace ReverseMarkdown.Converters
     {
         public Drop(Converter converter) : base(converter)
         {
+            if (Converter.Config.RemoveComments) {
+                converter.Register("#comment", this);
+            }
         }
 
         public override string Convert(HtmlNode node)


### PR DESCRIPTION
Excess comment removal removed closing style tag. Fix comment removal logic.