### PR TITLE
Handle P and Div tags within table cell by removing leading and trailing newlines.

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1027,7 +1027,7 @@ namespace ReverseMarkdown.Test
         {
             const string html =
                 @"Hello there <!-- This is a HTML comment block which will be removed! --><!-- This wont be removed because it is incomplete";
-            const string expected = @"Hello there <!-- This wont be removed because it is incomplete";
+            const string expected = @"Hello there ";
 
             var config = new Config
             {
@@ -1154,5 +1154,37 @@ namespace ReverseMarkdown.Test
 
             CheckConversion(html, expected);
         }
+
+        [Fact(Skip = "Issue 61. Unclosed CDATA tags are invalid and HtmlAgilityPack won't parse it correctly. Browsers doesn't parse them correctly too.")]
+        public void WhenUnclosedStyleTag_WithBypassUnknownTags_ThenConvertToMarkdown() {
+            string html = @"<html><head><style></head><body><p>Test content</p></body></html>";
+            string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
+
+            CheckConversion(html, expected, new Config() {
+                UnknownTags = Config.UnknownTagsOption.Bypass
+            });
+        }
+
+        [Fact(Skip = "Issue 61. Unclosed CDATA tags are invalid and HtmlAgilityPack won't parse it correctly. Browsers doesn't parse them correctly too.")]
+        public void WhenUnclosedScriptTag_WithBypassUnknownTags_ThenConvertToMarkdown() {
+            string html = @"<html><body><script><p>Test content</p></body></html>";
+            string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
+
+            CheckConversion(html, expected, new Config() {
+                UnknownTags = Config.UnknownTagsOption.Bypass
+            });
+        }
+
+        [Fact]
+        public void WhenCommentOverlapTag_WithRemoveComments_ThenDoNotStripContentBetweenComments() {
+            string html = @"<p>test <!-- comment -->content<!-- another comment --></p>";
+            string expected = $"{Environment.NewLine}Test content{Environment.NewLine}";
+
+            CheckConversion(html, expected, new Config() {
+                RemoveComments = true
+            });
+        }
+
+
     }
 }

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1154,7 +1154,8 @@ namespace ReverseMarkdown.Test
 
             CheckConversion(html, expected);
         }
-		[Fact]
+        
+        [Fact]
         public void WhenTableCellsWithP_ThenDoNotAddNewlines() {
             string html = $@"<html><body><table><tbody><tr><td><p>col1</p></td><td><p>col2</p></td></tr><tr><td><p>data1</p></td><td><p>data2</p></td></tr></tbody></table></body></html>";
             var expected = $"{Environment.NewLine}{Environment.NewLine}";

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -880,7 +880,7 @@ namespace ReverseMarkdown.Test
             var expected = $"{Environment.NewLine}{Environment.NewLine}";
             expected += $"| col1 |{Environment.NewLine}";
             expected += $"| --- |{Environment.NewLine}";
-            expected += $"| line1<br><br>line2<br> |{Environment.NewLine}";
+            expected += $"| line1<br><br>line2 |{Environment.NewLine}";
             expected += Environment.NewLine;
 
             CheckConversion(html, expected);
@@ -1154,6 +1154,74 @@ namespace ReverseMarkdown.Test
 
             CheckConversion(html, expected);
         }
+		[Fact]
+        public void WhenTableCellsWithP_ThenDoNotAddNewlines() {
+            string html = $@"<html><body><table><tbody><tr><td><p>col1</p></td><td><p>col2</p></td></tr><tr><td><p>data1</p></td><td><p>data2</p></td></tr></tbody></table></body></html>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| col1 | col2 |{Environment.NewLine}";
+            expected += $"| --- | --- |{Environment.NewLine}";
+            expected += $"| data1 | data2 |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
+        public void WhenTableCellsWithDiv_ThenDoNotAddNewlines() {
+            string html = $@"<html><body><table><tbody><tr><td><div>col1</div></td><td><div>col2</div></td></tr><tr><td><div>data1</div></td><td><div>data2</div></td></tr></tbody></table></body></html>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| col1 | col2 |{Environment.NewLine}";
+            expected += $"| --- | --- |{Environment.NewLine}";
+            expected += $"| data1 | data2 |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
+        public void WhenTableCellsWithPWithMarkupNewlines_ThenTrimExcessNewlines() {
+            string html = $"<html><body><table><tbody>{Environment.NewLine}\t<tr>{Environment.NewLine}\t\t<td>{Environment.NewLine}\t\t\t<p>{Environment.NewLine}col1{Environment.NewLine}</p>{Environment.NewLine}\t\t</td>{Environment.NewLine}\t<tr>{Environment.NewLine}\t\t<td>{Environment.NewLine}\t\t\t<p>{Environment.NewLine}data1{Environment.NewLine}</p>{Environment.NewLine}\t\t</td>\t</tr></tbody></table></body></html>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| col1 |{Environment.NewLine}";
+            expected += $"| --- |{Environment.NewLine}";
+            expected += $"| data1 |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
+        public void WhenTableCellsWithP_ThenNoNewlines() {
+            string html = $@"<table><tr><td><p>data1</p></td></tr></table>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| data1 |{Environment.NewLine}";
+            expected += $"| --- |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
+        public void WhenTableCellsWithMultipleP_ThenNoNewlines() {
+            string html = $@"<table><tr><td><p>p1</p><p>p2</p></td></tr></table>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| p1<br><br>p2 |{Environment.NewLine}";
+            expected += $"| --- |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected);
+        }
+
+        [Fact]
+        public void WhenTableCellsWithDataAndP_ThenNewlineBeforeP() {
+            string html = $@"<table><tr><td>data1<p>p</p></td></tr></table>";
+            var expected = $"{Environment.NewLine}{Environment.NewLine}";
+            expected += $"| data1<br>p |{Environment.NewLine}";
+            expected += $"| --- |{Environment.NewLine}";
+            expected += Environment.NewLine;
+
+            CheckConversion(html, expected);
+        }
 
         [Fact(Skip = "Issue 61. Unclosed CDATA tags are invalid and HtmlAgilityPack won't parse it correctly. Browsers doesn't parse them correctly too.")]
         public void WhenUnclosedStyleTag_WithBypassUnknownTags_ThenConvertToMarkdown() {
@@ -1184,7 +1252,5 @@ namespace ReverseMarkdown.Test
                 RemoveComments = true
             });
         }
-
-
     }
 }

--- a/src/ReverseMarkdown/Cleaner.cs
+++ b/src/ReverseMarkdown/Cleaner.cs
@@ -4,20 +4,13 @@ using System.Text.RegularExpressions;
 
 namespace ReverseMarkdown
 {
-    public class Cleaner
+    public static class Cleaner
     {
         private static string CleanTagBorders(string content)
         {
             // content from some htl editors such as CKEditor emits newline and tab between tags, clean that up
             content = content.Replace("\n\t", "");
             content = content.Replace(Environment.NewLine + "\t", "");
-            return content;
-        }
-
-        private static string RemoveComments(string content)
-        {
-            // optionally remove HTML comment tags from content (i.e `<!-- this is a comment block -->`)
-            content = Regex.Replace(content, @"<!--(\n|.)*-->", "");
             return content;
         }
 
@@ -32,11 +25,6 @@ namespace ReverseMarkdown
         {
             content = NormalizeSpaceChars(content);
             content = CleanTagBorders(content);
-
-            if (removeComments)
-            {
-                content = RemoveComments(content);
-            }
 
             return content;
         }

--- a/src/ReverseMarkdown/Converters/Div.cs
+++ b/src/ReverseMarkdown/Converters/Div.cs
@@ -13,7 +13,7 @@ namespace ReverseMarkdown.Converters
 
         public override string Convert(HtmlNode node)
         {
-            return $"{Environment.NewLine}{TreatChildren(node).Trim()}{Environment.NewLine}";
+            return $"{(Td.FirstNodeWithinCell(node) ? "" : Environment.NewLine)}{TreatChildren(node).Trim()}{(Td.LastNodeWithinCell(node) ? "" : Environment.NewLine)}";
         }
     }
 }

--- a/src/ReverseMarkdown/Converters/Drop.cs
+++ b/src/ReverseMarkdown/Converters/Drop.cs
@@ -6,6 +6,9 @@ namespace ReverseMarkdown.Converters
     {
         public Drop(Converter converter) : base(converter)
         {
+            if (Converter.Config.RemoveComments) {
+                converter.Register("#comment", this);
+            }
         }
 
         public override string Convert(HtmlNode node)

--- a/src/ReverseMarkdown/Converters/P.cs
+++ b/src/ReverseMarkdown/Converters/P.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 
 namespace ReverseMarkdown.Converters
@@ -12,10 +12,11 @@ namespace ReverseMarkdown.Converters
             Converter.Register("p", this);
         }
 
-        public override string Convert(HtmlNode node)
-        {
+        public override string Convert(HtmlNode node) {
             var indentation = IndentationFor(node);
-            return $"{indentation}{TreatChildren(node).Trim()}{Environment.NewLine}";
+            var newlineAfter = NewlineAfter(node);
+
+            return $"{indentation}{TreatChildren(node).Trim()}{newlineAfter}";
         }
 
         private static string IndentationFor(HtmlNode node)
@@ -29,10 +30,11 @@ namespace ReverseMarkdown.Converters
                 return new string(' ', length * 4);
 
             // If p is at the start of a table cell, no leading newline
-            if ((parentName == "td" || parentName == "th") && node.ParentNode.FirstChild == node)
-                return string.Empty;
+            return Td.FirstNodeWithinCell(node) ? "" : Environment.NewLine;
+        }
 
-            return Environment.NewLine;
+        private string NewlineAfter(HtmlNode node) {
+            return Td.LastNodeWithinCell(node) ? "" : Environment.NewLine;
         }
     }
 }

--- a/src/ReverseMarkdown/Converters/Td.cs
+++ b/src/ReverseMarkdown/Converters/Td.cs
@@ -34,7 +34,7 @@ namespace ReverseMarkdown.Converters
             // If p is at the start of a table cell, no leading newline
             if (parentName == "td" || parentName == "th") {
                 var pNodeIndex = node.ParentNode.ChildNodes.GetNodeIndex(node);
-                var firstNodeIsWhitespace = node.ParentNode.FirstChild?.Name == "#text" && Regex.IsMatch(node.ParentNode.FirstChild?.InnerText, @"^\s*$");
+                var firstNodeIsWhitespace = node.ParentNode.FirstChild.Name == "#text" && Regex.IsMatch(node.ParentNode.FirstChild.InnerText, @"^\s*$");
                 if (pNodeIndex == 0 || (firstNodeIsWhitespace && pNodeIndex == 1)) return true;
             }
             return false;
@@ -49,7 +49,7 @@ namespace ReverseMarkdown.Converters
             if (parentName == "td" || parentName == "th") {
                 var pNodeIndex = node.ParentNode.ChildNodes.GetNodeIndex(node);
                 var cellNodeCount = node.ParentNode.ChildNodes.Count;
-                var lastNodeIsWhitespace = node.ParentNode.LastChild?.Name == "#text" && Regex.IsMatch(node.ParentNode.LastChild?.InnerText, @"^\s*$");
+                var lastNodeIsWhitespace = node.ParentNode.LastChild.Name == "#text" && Regex.IsMatch(node.ParentNode.LastChild.InnerText, @"^\s*$");
                 if (pNodeIndex == cellNodeCount - 1 || (lastNodeIsWhitespace && pNodeIndex == cellNodeCount - 2)) return true;
             }
             return false;

--- a/src/ReverseMarkdown/Converters/Td.cs
+++ b/src/ReverseMarkdown/Converters/Td.cs
@@ -34,7 +34,7 @@ namespace ReverseMarkdown.Converters
             // If p is at the start of a table cell, no leading newline
             if (parentName == "td" || parentName == "th") {
                 var pNodeIndex = node.ParentNode.ChildNodes.GetNodeIndex(node);
-                var firstNodeIsWhitespace = node.ParentNode.FirstChild?.Name == "#text" && Regex.IsMatch(node.ParentNode.FirstChild?.InnerText, @"^\s+$");
+                var firstNodeIsWhitespace = node.ParentNode.FirstChild?.Name == "#text" && Regex.IsMatch(node.ParentNode.FirstChild?.InnerText, @"^\s*$");
                 if (pNodeIndex == 0 || (firstNodeIsWhitespace && pNodeIndex == 1)) return true;
             }
             return false;
@@ -49,7 +49,7 @@ namespace ReverseMarkdown.Converters
             if (parentName == "td" || parentName == "th") {
                 var pNodeIndex = node.ParentNode.ChildNodes.GetNodeIndex(node);
                 var cellNodeCount = node.ParentNode.ChildNodes.Count;
-                var lastNodeIsWhitespace = node.ParentNode.LastChild?.Name == "#text" && Regex.IsMatch(node.ParentNode.LastChild?.InnerText, @"^\s+$");
+                var lastNodeIsWhitespace = node.ParentNode.LastChild?.Name == "#text" && Regex.IsMatch(node.ParentNode.LastChild?.InnerText, @"^\s*$");
                 if (pNodeIndex == cellNodeCount - 1 || (lastNodeIsWhitespace && pNodeIndex == cellNodeCount - 2)) return true;
             }
             return false;

--- a/src/ReverseMarkdown/Converters/Td.cs
+++ b/src/ReverseMarkdown/Converters/Td.cs
@@ -1,5 +1,6 @@
 ﻿using HtmlAgilityPack;
 using System;
+using System.Text.RegularExpressions;
 
 namespace ReverseMarkdown.Converters
 {
@@ -21,6 +22,37 @@ namespace ReverseMarkdown.Converters
                 .Replace(Environment.NewLine, "<br>");
 
             return $" {content} |";
+        }
+
+        /// <summary>
+        /// Given node within td tag, checks if newline should be prepended. Will not prepend if this is the first node after any whitespace
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        public static bool FirstNodeWithinCell(HtmlNode node) {
+            var parentName = node.ParentNode.Name;
+            // If p is at the start of a table cell, no leading newline
+            if (parentName == "td" || parentName == "th") {
+                var pNodeIndex = node.ParentNode.ChildNodes.GetNodeIndex(node);
+                var firstNodeIsWhitespace = node.ParentNode.FirstChild?.Name == "#text" && Regex.IsMatch(node.ParentNode.FirstChild?.InnerText, @"^\s+$");
+                if (pNodeIndex == 0 || (firstNodeIsWhitespace && pNodeIndex == 1)) return true;
+            }
+            return false;
+        }
+        /// <summary>
+        /// Given node within td tag, checks if newline should be appended. Will not append if this is the last node before any whitespace
+        /// </summary>
+        /// <param name="node"></param>
+        /// <returns></returns>
+        public static bool LastNodeWithinCell(HtmlNode node) {
+            var parentName = node.ParentNode.Name;
+            if (parentName == "td" || parentName == "th") {
+                var pNodeIndex = node.ParentNode.ChildNodes.GetNodeIndex(node);
+                var cellNodeCount = node.ParentNode.ChildNodes.Count;
+                var lastNodeIsWhitespace = node.ParentNode.LastChild?.Name == "#text" && Regex.IsMatch(node.ParentNode.LastChild?.InnerText, @"^\s+$");
+                if (pNodeIndex == cellNodeCount - 1 || (lastNodeIsWhitespace && pNodeIndex == cellNodeCount - 2)) return true;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
Additionally ignore markup whitespace (newlines) infriltrating into resulting markdown for tables.