### PR TITLE
Fixed bug where Tr first row check was invalid

### DIFF
--- a/src/ReverseMarkdown/Converters/Tr.cs
+++ b/src/ReverseMarkdown/Converters/Tr.cs
@@ -34,7 +34,7 @@ namespace ReverseMarkdown.Converters
         private bool UseFirstRowAsHeaderRow(HtmlNode node)
         {
             var tableNode = node.Ancestors("table").FirstOrDefault();
-            var firstRow = tableNode?.SelectSingleNode("//tr");
+            var firstRow = tableNode?.SelectSingleNode(".//tr");
 
             if (firstRow == null)
             {
@@ -42,7 +42,7 @@ namespace ReverseMarkdown.Converters
             }
 
             var isFirstRow = firstRow == node;
-            var hasNoHeaderRow = tableNode.SelectNodes("//th")?.FirstOrDefault() == null;
+            var hasNoHeaderRow = tableNode.SelectNodes(".//th")?.FirstOrDefault() == null;
 
             return isFirstRow
                    && hasNoHeaderRow


### PR DESCRIPTION
The UseFirstRowAsHeaderRow check didn't check if first row of parent table, it checked if same as first existing tr in document. The bug occurs when there are more than one table in Html.