### PR TITLE
Fix: Style tag within bypass mode. If Style tag within body (happens …

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -739,6 +739,15 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
+        public void WhenStyletagWithBypassOption_ReturnEmpty() {
+            const string html = @"<body><style type=""text/css"">.main {background-color: #ffffff;}</style></body>";
+            const string expected = "";
+            CheckConversion(html, expected, new Config() {
+                UnknownTags = Config.UnknownTagsOption.Bypass
+            });
+        }
+
+        [Fact]
         public void Check_Converter_With_Unknown_Tag_Drop_Option()
         {
             const string html = @"<unknown-tag>text in unknown tag</unknown-tag><p>paragraph text</p>";

--- a/src/ReverseMarkdown/Converters/Drop.cs
+++ b/src/ReverseMarkdown/Converters/Drop.cs
@@ -6,6 +6,7 @@ namespace ReverseMarkdown.Converters
     {
         public Drop(Converter converter) : base(converter)
         {
+            Converter.Register("style", this);
             if (Converter.Config.RemoveComments) {
                 converter.Register("#comment", this);
             }


### PR DESCRIPTION
…from some email providers), it will put out style text.

Fixed by droppoing Style tag.

Input: 
```html
<body><style type="text/css">.main {background-color: #ffffff;}</style></body>
```
Output before:
```
.main {background-color: #ffffff;}
```

Output now:
```
```