### PR TITLE
Add support for parsing additional Syntax Coloring schemes on import

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1172,7 +1172,7 @@ namespace ReverseMarkdown.Test
 
             var html =
                 $@"<pre><code class=""language-xml hljs""><span class=""hljs-tag"">&lt;<span class=""hljs-name"">AspNetCoreHostingModel</span>&gt;</span>InProcess<span class=""hljs-tag"">&lt;/<span class=""hljs-name"">AspNetCoreHostingModel</span>&gt;</span>{Environment.NewLine}</code></pre>";
-            var expected = $@"{Environment.NewLine}```{Environment.NewLine}<AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>{Environment.NewLine}```{Environment.NewLine}";
+            var expected = $@"{Environment.NewLine}```xml{Environment.NewLine}<AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>{Environment.NewLine}```{Environment.NewLine}";
 
             var config = new ReverseMarkdown.Config
             {

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1021,6 +1021,47 @@ namespace ReverseMarkdown.Test
             Assert.Equal(expected, result);
         }
 
+
+        [Fact]
+        public void When_PRE_With_Github_Site_DIV_Parent_And_GitHubFlavored_Config_ThenConvertToGFM_PRE()
+        {
+            const string html = @"<div class=""highlight highlight-source-csharp""><pre>var test = ""hello world"";</pre></div>";
+            var expected = Environment.NewLine;
+            expected += $"```csharp{Environment.NewLine}";
+            expected += $@"var test = ""hello world"";{Environment.NewLine}";
+            expected += $"```{Environment.NewLine}";
+
+            var config = new Config
+            {
+                GithubFlavored = true
+            };
+
+            var converter = new Converter(config);
+            var result = converter.Convert(html);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void When_PRE_With_HighlightJs_Lang_Class_Att_And_GitHubFlavored_Config_ThenConvertToGFM_PRE()
+        {
+            const string html = @"<pre><code class=""hljs language-csharp"">var test = ""hello world"";</code></pre>";
+            var expected = Environment.NewLine;
+            expected += $"```csharp{Environment.NewLine}";
+            expected += $@"var test = ""hello world"";{Environment.NewLine}";
+            expected += $"```{Environment.NewLine}";
+
+            var config = new Config
+            {
+                GithubFlavored = true
+            };
+
+            var converter = new Converter(config);
+            var result = converter.Convert(html);
+
+            Assert.Equal(expected, result);
+        }
+
         [Fact]
         public void When_PRE_With_Lang_Highlight_Class_Att_And_GitHubFlavored_Config_ThenConvertToGFM_PRE()
         {

--- a/src/ReverseMarkdown/Converters/Pre.cs
+++ b/src/ReverseMarkdown/Converters/Pre.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 
 namespace ReverseMarkdown.Converters
@@ -34,16 +34,57 @@ namespace ReverseMarkdown.Converters
 
         private string GetLanguage(HtmlNode node)
         {
-            var lang = GetLanguageFromHighlightClassAttribute(node);
-            return lang !=string.Empty ? lang : GetLanguageFromConfluenceClassAttribute(node); 
+            return GetLanguageFromHighlightClassAttribute(node);
         }
+
 
         private static string GetLanguageFromHighlightClassAttribute(HtmlNode node)
         {
+            var res = ClassMatch(node); 
+            
+            // check parent node:
+            // GitHub: <div class="highlight highlight-source-json"><pre> 
+            // BitBucket: <div class="codehilite language-json"><pre>
+            if (!res.Success && node.ParentNode != null)
+            {
+                res = ClassMatch(node.ParentNode);
+            }
+
+            // check child <code> node:
+            // HighlightJs: <pre><code class="hljs language-json">
+            if (!res.Success)
+            {
+                var cnode = node.ChildNodes["code"];
+                if (cnode != null)
+                {
+                    res = ClassMatch(cnode);
+                }
+            }
+			
+            return res.Success && res.Groups.Count == 3 ? res.Groups[2].Value : string.Empty;
+        }
+
+        /// <summary>
+        /// Extracts class attribute syntax using: highlight-json, highlight-source-json, language-json, brush: language
+        /// Returns the Language in Match.Groups[2]
+        /// </summary>
+        private static readonly Regex ClassRegex = new Regex(@"(highlight-source-|language-|highlight-|brush:\s)([a-zA-Z0-9]+)");
+
+        /// <summary>
+        /// Checks class attribute for language class identifiers for various
+        /// common highlighters
+        /// </summary>
+        /// <param name="node">Node with class attribute</param>
+        /// <returns>Match.Success and Match.Group[2] set to the language</returns>
+        private static Match ClassMatch(HtmlNode node)
+        {
             var val = node.GetAttributeValue("class", "");
-            var rx = new System.Text.RegularExpressions.Regex("highlight-([a-zA-Z0-9]+)");
-            var res = rx.Match(val);
-            return res.Success ? res.Value.Split('-')[1].Replace(";", "").Trim() : "";
+            if (!string.IsNullOrEmpty(val))
+            {
+                return ClassRegex.Match(val);
+            }
+
+            return Match.Empty;
         }
 
         private static string GetLanguageFromConfluenceClassAttribute(HtmlNode node)

--- a/src/ReverseMarkdown/Converters/Pre.cs
+++ b/src/ReverseMarkdown/Converters/Pre.cs
@@ -86,13 +86,5 @@ namespace ReverseMarkdown.Converters
 
             return Match.Empty;
         }
-
-        private static string GetLanguageFromConfluenceClassAttribute(HtmlNode node)
-        {
-            var val = node.GetAttributeValue("class", "");
-            var rx = new System.Text.RegularExpressions.Regex(@"brush:\s?(:?.*)");
-            var res = rx.Match(val);
-            return res.Success ? res.Value.Split(':')[1].Replace(";","").Trim() : "";
-        }
     }
 }


### PR DESCRIPTION
- Check current node (`<pre>`)
- Check Parent node (div tag usually: Github, BitBucket, a few others)
- Check Child `<code>` node
- Check for several different language identifiers: highlight-, highlight-source, language and confluence brush:\s
- Remove explicit Confluence check and roll into the single regEx handler

This should handle support for:

* Github
```html
<div class="highlight highlight-source-json"><pre>...</pre></div>
```

* HighlightJs
```html
<pre><code class="hljs language-json">...</code></pre>
```

* BitBucket
```html
<div class="codehilite language-json"><pre>..</pre></div>
```

* Confluence ( Not really sure where this is used but just migrated the existing functionality)
```html
<pre class=""brush: python;"">...</pre>"
```