### PR TITLE
Remove extra blank line after fenced code block

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.When_FencedCodeBlocks_Shouldnt_Have_Trailing_Line.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_FencedCodeBlocks_Shouldnt_Have_Trailing_Line.verified.md
@@ -3,4 +3,3 @@
 ```xml
 <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
 ```
-

--- a/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_Confluence_Lang_Class_Att_And_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_Confluence_Lang_Class_Att_And_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
@@ -3,4 +3,3 @@
 ```python
 var test = 'hello world';
 ```
-

--- a/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
@@ -3,4 +3,3 @@
 ```
 var test = 'hello world';
 ```
-

--- a/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_Github_Site_DIV_Parent_And_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_Github_Site_DIV_Parent_And_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
@@ -3,4 +3,3 @@
 ```csharp
 var test = "hello world";
 ```
-

--- a/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_HighlightJs_Lang_Class_Att_And_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_HighlightJs_Lang_Class_Att_And_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
@@ -3,4 +3,3 @@
 ```csharp
 var test = "hello world";
 ```
-

--- a/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_Lang_Highlight_Class_Att_And_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_PRE_With_Lang_Highlight_Class_Att_And_GitHubFlavored_Config_ThenConvertToGFM_PRE.verified.md
@@ -3,4 +3,3 @@
 ```python
 var test = 'hello world';
 ```
-

--- a/src/ReverseMarkdown.Test/ConverterTests.When_PRE_Without_Lang_Marker_Class_Att_And_GitHubFlavored_Config_With_DefaultCodeBlockLanguage_ThenConvertToGFM_PRE.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_PRE_Without_Lang_Marker_Class_Att_And_GitHubFlavored_Config_With_DefaultCodeBlockLanguage_ThenConvertToGFM_PRE.verified.md
@@ -3,4 +3,3 @@
 ```csharp
 var test = "hello world";
 ```
-

--- a/src/ReverseMarkdown/Converters/Pre.cs
+++ b/src/ReverseMarkdown/Converters/Pre.cs
@@ -32,7 +32,7 @@ namespace ReverseMarkdown.Converters
             {
                 var lang = GetLanguage(node);
                 fencedCodeStartBlock = $"{indentation}```{lang}{Environment.NewLine}";
-                fencedCodeEndBlock = $"{indentation}```{Environment.NewLine}";
+                fencedCodeEndBlock = $"{indentation}```";
             }
             else
             {


### PR DESCRIPTION
ReverseMarkdown adds two blank lines after a fenced code block (but only one blank line after an indented code block).

The two blank lines after a fenced code block violate the following [markdownlint](https://github.com/DavidAnson/markdownlint) rule:

> [MD012 - Multiple consecutive blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md012---multiple-consecutive-blank-lines)
>
> This rule is triggered when there are multiple consecutive blank lines in the document:
>
>     Some text here
>     
>     
>     Some more text here
>
> To fix this, delete the offending lines:
>
>     Some text here
>     
>     Some more text here
