### PR TITLE
Fix list items with multiple paragraphs

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.WhenListContainsMultipleParagraphs_ConvertToMarkdownAndIndentSiblings.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.WhenListContainsMultipleParagraphs_ConvertToMarkdownAndIndentSiblings.verified.md
@@ -1,5 +1,6 @@
 
 1. Paragraph 1
-    Paragraph 2
+    Paragraph 1.1
+    Paragraph 1.2
 2. Paragraph 3
 

--- a/src/ReverseMarkdown.Test/ConverterTests.WhenListContainsMultipleParagraphs_ConvertToMarkdownAndIndentSiblings.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.WhenListContainsMultipleParagraphs_ConvertToMarkdownAndIndentSiblings.verified.md
@@ -1,5 +1,5 @@
 
-1. Item1
-    Item2
-2. Item3
+1. Paragraph 1
+    Paragraph 2
+2. Paragraph 3
 

--- a/src/ReverseMarkdown.Test/ConverterTests.WhenListContainsMultipleParagraphs_ConvertToMarkdownAndIndentSiblings.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.WhenListContainsMultipleParagraphs_ConvertToMarkdownAndIndentSiblings.verified.md
@@ -1,6 +1,8 @@
 
 1. Paragraph 1
+
     Paragraph 1.1
+
     Paragraph 1.2
 2. Paragraph 3
 

--- a/src/ReverseMarkdown.Test/ConverterTests.WhenListContainsParagraphsOutsideItems_ConvertToMarkdownAndIndentSiblings.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.WhenListContainsParagraphsOutsideItems_ConvertToMarkdownAndIndentSiblings.verified.md
@@ -1,5 +1,6 @@
 
 1. Item1
+
     Item 1 additional info
 2. Item2
 

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -579,7 +579,8 @@ namespace ReverseMarkdown.Test
 @"<ol>
 	<li>
 		<p>Paragraph 1</p>
-        <p>Paragraph 2</p></li>
+        <p>Paragraph 1.1</p>
+        <p>Paragraph 1.2</p></li>
 	<li>
 		<p>Paragraph 3</p></li></ol>";
 

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -578,10 +578,10 @@ namespace ReverseMarkdown.Test
             var html =
 @"<ol>
 	<li>
-		<p>Item1</p>
-        <p>Item2</p></li>
+		<p>Paragraph 1</p>
+        <p>Paragraph 2</p></li>
 	<li>
-		<p>Item3</p></li></ol>";
+		<p>Paragraph 3</p></li></ol>";
 
             return CheckConversion(html);
         }

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -575,14 +575,27 @@ namespace ReverseMarkdown.Test
         [Fact]
         public Task WhenListContainsMultipleParagraphs_ConvertToMarkdownAndIndentSiblings()
         {
-            var html = $"<ol>{Environment.NewLine}\t<li>{Environment.NewLine}\t\t<p>Item1</p>{Environment.NewLine}        <p>Item2</p></li>{Environment.NewLine}\t<li>{Environment.NewLine}\t\t<p>Item3</p></li></ol>";
+            var html =
+@"<ol>
+	<li>
+		<p>Item1</p>
+        <p>Item2</p></li>
+	<li>
+		<p>Item3</p></li></ol>";
+
             return CheckConversion(html);
         }
 
         [Fact]
         public Task WhenListContainsParagraphsOutsideItems_ConvertToMarkdownAndIndentSiblings()
         {
-            var html = $"<ol>{Environment.NewLine}\t<li>Item1</li>{Environment.NewLine}\t<p>Item 1 additional info</p>{Environment.NewLine}\t<li>Item2</li>{Environment.NewLine}</ol>";
+            var html =
+@"<ol>
+	<li>Item1</li>
+	<p>Item 1 additional info</p>
+	<li>Item2</li>
+</ol>";
+
             return CheckConversion(html);
         }
 

--- a/src/ReverseMarkdown/Converters/P.cs
+++ b/src/ReverseMarkdown/Converters/P.cs
@@ -23,11 +23,11 @@ namespace ReverseMarkdown.Converters
         {
             string parentName = node.ParentNode.Name.ToLowerInvariant();
 
-            // If p follows a list item, indent it instead of adding a leading newline
+            // If p follows a list item, add newline and indent it
             var length = node.Ancestors("ol").Count() + node.Ancestors("ul").Count();
             bool parentIsList = parentName == "li" || parentName == "ol" || parentName == "ul";
             if (parentIsList && node.ParentNode.FirstChild != node)
-                return new string(' ', length * 4);
+                return Environment.NewLine + (new string(' ', length * 4));
 
             // If p is at the start of a table cell, no leading newline
             return Td.FirstNodeWithinCell(node) ? "" : Environment.NewLine;


### PR DESCRIPTION
List items with multiple paragraphs do not render the expected Markdown. Specifically, there needs to be a blank line before each paragraph (except the first one in a list item).

To understand why, consider the HTML for one of the existing tests in ReverseMarkdown (`WhenListContainsMultipleParagraphs_ConvertToMarkdownAndIndentSiblings`):

```HTML
<ol>
	<li>
		<p>Item1</p>
        <p>Item2</p></li>
	<li>
		<p>Item3</p></li></ol>
```

Let's change the paragraph content to make it a little clearer:

```HTML
<ol>
	<li>
		<p>Paragraph 1</p>
        <p>Paragraph 2</p></li>
	<li>
		<p>Paragraph 3</p></li></ol>
```

With this change, the following Markdown content is generated by ReverseMarkdown:

```Markdown
1. Paragraph 1
    Paragraph 2
2. Paragraph 3
```

While the might seem okay at first, copy that into Visual Studio Code and then preview the HTML:

![image](https://user-images.githubusercontent.com/1385288/109845382-4d1a0480-7c0a-11eb-82fc-2fb363073c1f.png)

As you can see, "Paragraph 2" isn't recognized as a paragraph at all. Rather it is considered to be a continuation of the first paragraph.

Adding a blank line before "Paragraph 2" resolves the issue:

```Markdown
1. Paragraph 1

    Paragraph 2
2. Paragraph 3
```

![image](https://user-images.githubusercontent.com/1385288/109845697-a7b36080-7c0a-11eb-9bc6-9b0c209f5ad1.png)

