### PR TITLE
Correct empty <pre> behavior

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsEmptyPreTag_ThenConvertToMarkdownPre.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsEmptyPreTag_ThenConvertToMarkdownPre.verified.md
@@ -1,0 +1,5 @@
+This text has pre tag content 
+
+    
+
+Next line of text

--- a/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsEmptyPreTag_ThenConvertToMarkdownPre_GFM.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsEmptyPreTag_ThenConvertToMarkdownPre_GFM.verified.md
@@ -1,0 +1,6 @@
+This text has pre tag content 
+
+```
+
+```
+Next line of text

--- a/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsEmptyPreTag_ThenIgnorePre.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsEmptyPreTag_ThenIgnorePre.verified.md
@@ -1,1 +1,0 @@
-This text has pre tag content Next line of text

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -503,10 +503,17 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
-        public Task WhenThereIsEmptyPreTag_ThenIgnorePre()
+        public Task WhenThereIsEmptyPreTag_ThenConvertToMarkdownPre()
         {
             var html = "This text has pre tag content <pre><br/ ></pre>Next line of text";
             return CheckConversion(html);
+        }
+
+        [Fact]
+        public Task WhenThereIsEmptyPreTag_ThenConvertToMarkdownPre_GFM()
+        {
+            var html = "This text has pre tag content <pre><br/ ></pre>Next line of text";
+            return CheckConversion(html, new Config { GithubFlavored = true });
         }
 
         [Fact]

--- a/src/ReverseMarkdown/Converters/Pre.cs
+++ b/src/ReverseMarkdown/Converters/Pre.cs
@@ -16,11 +16,6 @@ namespace ReverseMarkdown.Converters
         {
             var content = DecodeHtml(node.InnerText);
 
-            if (string.IsNullOrEmpty(content))
-            {
-                return string.Empty;
-            }
-
             // check if indentation need to be added if it is under a ordered or unordered list
             var indentation = IndentationFor(node);
 
@@ -41,6 +36,12 @@ namespace ReverseMarkdown.Converters
 
             var lines = content.ReadLines().Select(item => indentation + item);
             content = string.Join(Environment.NewLine, lines);
+
+            if (string.IsNullOrEmpty(content)
+                && Converter.Config.GithubFlavored == false)
+            {
+                content = indentation;
+            }
 
             return $"{Environment.NewLine}{Environment.NewLine}{fencedCodeStartBlock}{content}{Environment.NewLine}{fencedCodeEndBlock}{Environment.NewLine}";
         }


### PR DESCRIPTION
The current behavior for handling empty `<pre>` elements does not reflect the equivalent HTML rendering.

Here is the HTML from the test (`WhenThereIsEmptyPreTag_ThenIgnorePre`):

```HTML
This text has pre tag content <pre><br/ ></pre>Next line of text
```

If you copy that into an HTML document and view it in a browser, it looks something like this:

![image](https://user-images.githubusercontent.com/1385288/109892955-14991b80-7c48-11eb-94bf-60ce442f758c.png)

However, if you take the Markdown currently generated by ReverseMarkdown, you get something that looks like this:

![image](https://user-images.githubusercontent.com/1385288/109893301-a2750680-7c48-11eb-87c4-9512d5f010c6.png)

This change replaces the expected Markdown in this scenario with a line of 4 spaces (or, more accurately, the number of spaces corresponding to the indentation level for the `<pre>` element -- when the element resides in a list).

```Markdown
This text has pre tag content 

    

Next line of text
```

> **Note:**
>
> I will be the first to admit that outputting a line consisting entirely of spaces "feels wrong" -- but so does the original HTML.

This is a very obscure scenario and admittedly not one that is likely encountered in "the real world." However, this test fails in a different branch that I'm working on, and I'd rather not implement a "hack" to get it to pass.