### PR TITLE
Add support for <sup> tag conversion

### DIFF
--- a/src/ReverseMarkdown.Test/ConverterTests.When_Sup_And_Nested_Sup.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_Sup_And_Nested_Sup.md
@@ -1,0 +1,1 @@
+This is the 1^st^ sentence to t^es^t the sup tag conversion

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1311,5 +1311,12 @@ namespace ReverseMarkdown.Test
                 $"<table><tr><th style=\"text-align:left\">Col1</th><th style=\"text-align:center\">Col2</th><th style=\"text-align:right\">Col2</th></tr><tr><td>1</td><td>2</td><td>3</td></tr></table>";
             return CheckConversion(html);
         }
+
+        [Fact]
+        public Task When_Sup_And_Nested_Sup()
+        {
+            var html = $"This is the 1<sup>st</sup> sentence to t<sup>e<sup>s</sup></sup>t the sup tag conversion";
+            return CheckConversion(html);
+        }
     }
 }

--- a/src/ReverseMarkdown/Converters/Sup.cs
+++ b/src/ReverseMarkdown/Converters/Sup.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using HtmlAgilityPack;
+
+namespace ReverseMarkdown.Converters
+{
+    public class Sup : ConverterBase
+    {
+        public Sup(Converter converter) : base(converter)
+        {
+            Converter.Register("sup", this);   
+        }
+
+        public override string Convert(HtmlNode node)
+        {
+            var content = TreatChildren(node);
+            if (string.IsNullOrEmpty(content) || AlreadySup(node))
+            {
+                return content;
+            }
+            else
+            {
+                return $"^{content.Trim().Chomp(all:true)}^";
+            }
+        }
+
+        private static bool AlreadySup(HtmlNode node)
+        {
+            return node.Ancestors("sup").Any();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the <sup> tag, since it's not supported natively everywhere.
Nested tags are not supported in Markdown, so the content gets appended to the parent tag.