### PR TITLE
adds newline suppression for divs

### DIFF
--- a/README.source.md
+++ b/README.source.md
@@ -59,6 +59,7 @@ var converter = new ReverseMarkdown.Converter(config);
 
 * `DefaultCodeBlockLanguage` - Option to set the default code block language for Github style markdown if class based language markers are not available
 * `GithubFlavored` - Github style markdown for br, pre and table. Default is false
+* `SuppressNewlines` - Removes prefixed newlines from `div` tags. Default is false
 * `ListBulletChar` - Allows you to change the bullet character. Default value is `-`. Some systems expect the bullet character to be `*` rather than `-`, this config allows you to change it.
 * `RemoveComments` - Remove comment tags with text. Default is false
 * `SmartHrefHandling` - How to handle `<a>` tag href attribute

--- a/src/ReverseMarkdown.Test/ConverterTests.When_SuppressNewlineFlag_PrefixDiv_Should_Be_Empty.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_SuppressNewlineFlag_PrefixDiv_Should_Be_Empty.md
@@ -1,0 +1,4 @@
+the
+fox
+jumps
+over

--- a/src/ReverseMarkdown.Test/ConverterTests.When_SuppressNewlineFlag_PrefixDiv_Should_Be_Empty.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_SuppressNewlineFlag_PrefixDiv_Should_Be_Empty.verified.md
@@ -1,7 +1,4 @@
 ﻿the
-
 fox
-
 jumps
-
 over

--- a/src/ReverseMarkdown.Test/ConverterTests.When_SuppressNewlineFlag_PrefixDiv_Should_Be_Empty.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.When_SuppressNewlineFlag_PrefixDiv_Should_Be_Empty.verified.md
@@ -1,0 +1,7 @@
+﻿the
+
+fox
+
+jumps
+
+over

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1341,5 +1341,12 @@ namespace ReverseMarkdown.Test
             var html = $"... example html <i>code </i>block";
             return CheckConversion(html);
         }
+
+        [Fact]
+        public Task When_SuppressNewlineFlag_PrefixDiv_Should_Be_Empty()
+        {
+            var html = $"<div>the</div><div>fox</div><div>jumps</div><div>over</div>";
+            return CheckConversion(html);
+        }
     }
 }

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -1346,7 +1346,10 @@ namespace ReverseMarkdown.Test
         public Task When_SuppressNewlineFlag_PrefixDiv_Should_Be_Empty()
         {
             var html = $"<div>the</div><div>fox</div><div>jumps</div><div>over</div>";
-            return CheckConversion(html);
+            return CheckConversion(html, new Config
+            {
+                SuppressNewlines = true
+            });
         }
     }
 }

--- a/src/ReverseMarkdown/Config.cs
+++ b/src/ReverseMarkdown/Config.cs
@@ -8,6 +8,8 @@ namespace ReverseMarkdown
         public UnknownTagsOption UnknownTags { get; set; } = UnknownTagsOption.PassThrough;
 
         public bool GithubFlavored { get; set; } = false;
+        
+        public bool SuppressNewlines { get; set; } = false;
 
         public bool RemoveComments { get; set; } = false;
 

--- a/src/ReverseMarkdown/Converters/Div.cs
+++ b/src/ReverseMarkdown/Converters/Div.cs
@@ -42,7 +42,18 @@ namespace ReverseMarkdown.Converters
                 return content;
             }
 
-            return $"{(Td.FirstNodeWithinCell(node) ? "" : Environment.NewLine)}{content}{(Td.LastNodeWithinCell(node) ? "" : Environment.NewLine)}";
+            var prefix = Environment.NewLine;
+
+            if (Td.FirstNodeWithinCell(node))
+            {
+                prefix = string.Empty;
+            } 
+            else if (Converter.Config.SuppressNewlines)
+            {
+                prefix = string.Empty;
+            }
+            
+            return $"{prefix}{content}{(Td.LastNodeWithinCell(node) ? "" : Environment.NewLine)}";
         }
     }
 }


### PR DESCRIPTION
# DISCLAIMER: I am a Microsoft employee making a contribution to this opensource project for use by downstream Microsoft products. If you would like to learn more, please contact cela@microsoft.com.

In some cases there is HTML that will wrap standard text in `div` tags like this

```
<div>hello</div><div>world</div>
```

The default behavior for the ReverseMarkdown library is to append two newlines for each item, a prefix and suffix `\r\n` per `div` tag, resulting in something that looks like this:

```

hello

world
```

In this PR, I propose adding a new `Config` option called `SuppressNewlines` that will remove the prefixed newline from `div` tags not enclosed in `td` tags, such that the output may look like the following:

```
hello
world
```


## also

would it be okay if the dotnet framework 4.7.2 builds were re-enabled? my product doesn't currently support dotnet core :(