### PR TITLE
[Draft] Converter Inheritance Support

### DIFF
--- a/src/ReverseMarkdown.Test/ChildConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ChildConverterTests.cs
@@ -1,0 +1,41 @@
+﻿using ReverseMarkdown.Converters;
+using ReverseMarkdown.Test.Children;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace ReverseMarkdown.Test
+{
+    public class ChildConverterTests
+    {
+        [Fact]
+        public void WhenConverter_A_IsReplacedByConverter_IgnoreAWhenHasClass()
+        {
+            var converter = new ReverseMarkdown.Converter(new Config(), typeof(IgnoreAWhenHasClass).Assembly);
+
+            var type = converter.GetType();
+            var prop = type.GetField("_converters", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            Assert.NotNull(prop);
+
+            var propValRaw = prop.GetValue(converter);
+
+            Assert.NotNull(propValRaw);
+
+            var propVal = (IDictionary<string, IConverter>)propValRaw;
+
+            Assert.NotNull(propVal);
+
+            var converters = propVal.Select(e => e.Value.GetType()).ToArray();
+
+            Assert.DoesNotContain(typeof(A), converters);
+            Assert.Contains(typeof(IgnoreAWhenHasClass), converters);
+        }
+    }
+}

--- a/src/ReverseMarkdown.Test/Children/IgnoreAWhenHasClass.cs
+++ b/src/ReverseMarkdown.Test/Children/IgnoreAWhenHasClass.cs
@@ -1,0 +1,28 @@
+﻿using HtmlAgilityPack;
+
+using ReverseMarkdown.Converters;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ReverseMarkdown.Test.Children
+{
+    internal class IgnoreAWhenHasClass : A
+    {
+        private readonly string _ignore = "ignore";
+
+        public IgnoreAWhenHasClass(Converter converter) : base(converter)
+        { }
+
+        public override string Convert(HtmlNode node)
+        {
+            if (node.HasClass(_ignore))
+                return "";
+
+            return base.Convert(node);
+        }
+    }
+}

--- a/src/ReverseMarkdown/Converter.cs
+++ b/src/ReverseMarkdown/Converter.cs
@@ -17,6 +17,8 @@ namespace ReverseMarkdown
 
         public Converter() : this(new Config()) {}
 
+        public Converter(Config config) : this(config, null) {}
+
         public Converter(Config config, params Assembly[] additionalAssemblies)
         {
             Config = config;
@@ -26,7 +28,8 @@ namespace ReverseMarkdown
                 typeof(IConverter).GetTypeInfo().Assembly
             };
 
-            assemblies.AddRange(additionalAssemblies);
+            if (!(additionalAssemblies is null))
+                assemblies.AddRange(additionalAssemblies);
 
             List<Type> types = new List<Type>();
             // instantiate all converters excluding the unknown tags converters

--- a/src/ReverseMarkdown/Converter.cs
+++ b/src/ReverseMarkdown/Converter.cs
@@ -10,27 +10,58 @@ namespace ReverseMarkdown
 {
     public class Converter
     {
-        private readonly IDictionary<string, IConverter> _converters = new Dictionary<string, IConverter>();
-        private readonly IConverter _passThroughTagsConverter;
-        private readonly IConverter _dropTagsConverter;
-        private readonly IConverter _byPassTagsConverter;
+        protected readonly IDictionary<string, IConverter> _converters = new Dictionary<string, IConverter>();
+        protected readonly IConverter _passThroughTagsConverter;
+        protected readonly IConverter _dropTagsConverter;
+        protected readonly IConverter _byPassTagsConverter;
 
         public Converter() : this(new Config()) {}
 
-        public Converter(Config config)
+        public Converter(Config config, params Assembly[] additionalAssemblies)
         {
             Config = config;
 
-            // instantiate all converters excluding the unknown tags converters
-            foreach (var ctype in typeof(IConverter).GetTypeInfo().Assembly.GetTypes()
-                .Where(t => t.GetTypeInfo().GetInterfaces().Contains(typeof(IConverter)) &&
-                !t.GetTypeInfo().IsAbstract
-                && t != typeof(PassThrough)
-                && t != typeof(Drop)
-                && t != typeof(ByPass)))
+            List<Assembly> assemblies = new List<Assembly>()
             {
-                Activator.CreateInstance(ctype, this);
+                typeof(IConverter).GetTypeInfo().Assembly
+            };
+
+            assemblies.AddRange(additionalAssemblies);
+
+            List<Type> types = new List<Type>();
+            // instantiate all converters excluding the unknown tags converters
+            foreach (var assembly in assemblies)
+            {
+                foreach (var ctype in assembly.GetTypes()
+                    .Where(t => t.GetTypeInfo().GetInterfaces().Contains(typeof(IConverter)) &&
+                    !t.GetTypeInfo().IsAbstract
+                    && t != typeof(PassThrough)
+                    && t != typeof(Drop)
+                    && t != typeof(ByPass)))
+                {
+                    // Check to see if any existing types are children/equal to
+                    // the type to add.
+                    if (types.Any(e => ctype.IsAssignableFrom(e)))
+                        // If they are, ignore the type.
+                        continue;
+
+                    // See if there is a type that is a parent of the
+                    // current type.
+                    Type toRemove = types.FirstOrDefault(e => e.IsAssignableFrom(ctype));
+                    // if there is ...
+                    if (!(toRemove is null))
+                        // ... remove the parent.
+                        types.Remove(toRemove);
+
+                    // finally, add the type.
+                    types.Add(ctype);
+                }
             }
+
+            // For each type to register ...
+            foreach (var ctype in types)
+                // ... activate them
+                Activator.CreateInstance(ctype, this);
 
             // register the unknown tags converters
             _passThroughTagsConverter = new PassThrough(this);
@@ -38,9 +69,9 @@ namespace ReverseMarkdown
             _byPassTagsConverter = new ByPass(this);
         }
 
-        public Config Config { get; }
+        public Config Config { get; protected set; }
 
-        public string Convert(string html)
+        public virtual string Convert(string html)
         {
             html = Cleaner.PreTidy(html, Config.RemoveComments);
 
@@ -63,12 +94,12 @@ namespace ReverseMarkdown
             return result.Trim();
         }
 
-        public void Register(string tagName, IConverter converter)
+        public virtual void Register(string tagName, IConverter converter)
         {
             _converters[tagName] = converter;
         }
 
-        public IConverter Lookup(string tagName)
+        public virtual IConverter Lookup(string tagName)
         {
             // if a tag is in the pass through list then use the pass through tags converter
             if (Config.PassThroughTags.Contains(tagName))


### PR DESCRIPTION
## Changes
+ Added additional constructor with parameter (`param Assembly[] additionalAssemblies`) to the `Converter` constructor with support for custom converters and converters that inherit from existing converters.
+ Changed all `private readonly` fields in `Converter` to `protected readonly`
+ Changed all `public` methods in `Converter` to `public virtual`
+ Added test class/case for testing the constructor.

## Issues
Closes #384 