### PR TITLE
StringUtils: Trimming leading and trailing white-spaces when chomping "all"

### DIFF
--- a/src/ReverseMarkdown/StringUtils.cs
+++ b/src/ReverseMarkdown/StringUtils.cs
@@ -14,7 +14,8 @@ namespace ReverseMarkdown
             {
                 return content
                     .Replace("\r", "")
-                    .Replace("\n", "");
+                    .Replace("\n", "")
+                    .Trim();
             }
 
             return content.Trim().TrimEnd('\r', '\n');


### PR DESCRIPTION
Fixes an issue which produces invalid formatting of emphasis and strong emphasis when the HTML element contains leading or trailing white-spaces, which is not allowed within markdown (see https://spec.commonmark.org/0.31.2/#example-351).

Related to https://github.com/mysticmind/reversemarkdown-net/issues/388