### PR TITLE
Add support for "Github Flavored Markdown Task Lists"

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ var converter = new ReverseMarkdown.Converter(config);
 
 * Supports all the established html tags like h1, h2, h3, h4, h5, h6, p, em, strong, i, b, blockquote, code, img, a, hr, li, ol, ul, table, tr, th, td, br
 * Can deal with nested lists
-* Github Flavoured Markdown conversion supported for br, pre and table. Use `var config = new ReverseMarkdown.Config(githubFlavoured:true);`. By default table will always be converted to Github flavored markdown immaterial of this flag.
+* Github Flavoured Markdown conversion supported for br, pre, tasklists and table. Use `var config = new ReverseMarkdown.Config(githubFlavoured:true);`. By default table will always be converted to Github flavored markdown immaterial of this flag.
 
 ## Acknowledgements
 This library's initial implementation ideas were from the Ruby based Html to Markdown converter [ xijo/reverse_markdown](https://github.com/xijo/reverse_markdown).

--- a/README.source.md
+++ b/README.source.md
@@ -91,7 +91,7 @@ var converter = new ReverseMarkdown.Converter(config);
 
 * Supports all the established html tags like h1, h2, h3, h4, h5, h6, p, em, strong, i, b, blockquote, code, img, a, hr, li, ol, ul, table, tr, th, td, br
 * Supports nested lists
-* Github Flavoured Markdown conversion supported for br, pre and table. Use `var config = new ReverseMarkdown.Config(githubFlavoured:true);`. By default the table will always be converted to Github flavored markdown immaterial of this flag.
+* Github Flavoured Markdown conversion supported for br, pre, tasklists and table. Use `var config = new ReverseMarkdown.Config(githubFlavoured:true);`. By default the table will always be converted to Github flavored markdown immaterial of this flag.
 
 ## Acknowledgements
 This library's initial implementation ideas were from the Ruby based Html to Markdown converter [ xijo/reverse_markdown](https://github.com/xijo/reverse_markdown).

--- a/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsInputListWithGithubFlavoredDisabled_ThenConvertToTypicalMarkdownList.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsInputListWithGithubFlavoredDisabled_ThenConvertToTypicalMarkdownList.verified.md
@@ -1,0 +1,2 @@
+﻿- <input type="checkbox" disabled> Unchecked
+- <input type="checkbox" checked> Checked

--- a/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsInputListWithGithubFlavoredEnabled_ThenConvertToMarkdownCheckList.verified.md
+++ b/src/ReverseMarkdown.Test/ConverterTests.WhenThereIsInputListWithGithubFlavoredEnabled_ThenConvertToMarkdownCheckList.verified.md
@@ -1,0 +1,2 @@
+﻿- [ ] Unchecked
+- [x] Checked

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -975,7 +975,6 @@ namespace ReverseMarkdown.Test
         [Fact]
         public Task When_TextIsHtmlEncoded_DecodeText()
         {
-            var t = 0;
             var html = "<p>cat&#39;s</p>";
             return CheckConversion(html);
         }

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -542,6 +542,32 @@ namespace ReverseMarkdown.Test
         }
 
         [Fact]
+        public Task WhenThereIsInputListWithGithubFlavoredEnabled_ThenConvertToMarkdownCheckList()
+        {
+            var html = "<ul><li><input type=\"checkbox\" disabled> Unchecked</li><li><input type=\"checkbox\" checked> Checked</li></ul>";
+
+            var config = new Config
+            {
+                GithubFlavored = true,
+            };
+
+            return CheckConversion(html, config);
+        }
+
+        [Fact]
+        public Task WhenThereIsInputListWithGithubFlavoredDisabled_ThenConvertToTypicalMarkdownList()
+        {
+            var html = "<ul><li><input type=\"checkbox\" disabled> Unchecked</li><li><input type=\"checkbox\" checked> Checked</li></ul>";
+
+            var config = new Config
+            {
+                GithubFlavored = false,
+            };
+
+            return CheckConversion(html, config);
+        }
+
+        [Fact]
         public Task WhenThereIsOrderedList_ThenConvertToMarkdownList()
         {
             var html = "This text has ordered list.<ol><li>Item1</li><li>Item2</li></ol>";
@@ -949,6 +975,7 @@ namespace ReverseMarkdown.Test
         [Fact]
         public Task When_TextIsHtmlEncoded_DecodeText()
         {
+            var t = 0;
             var html = "<p>cat&#39;s</p>";
             return CheckConversion(html);
         }


### PR DESCRIPTION
This resolves issue #404 (Add support for "Github Flavored Markdown Task Lists")

Example:
**HTML:**
```html
<ul>
  <li><input type="checkbox" checked> Complete the project report</li>
  <li><input type="checkbox"> Submit the report</li>
  <li>This is a regular list item</li>
</ul>
```

**Converted Markdown:**

```md
- [x] Complete the project report
- [ ] Submit the report
- This is a regular list item
```

Markdown Preview:
- [x] Complete the project report
- [ ] Submit the report
- This is a regular list item