### PR TITLE
Normalize input line endings and make output line endings configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ var converter = new ReverseMarkdown.Converter(config);
 <sup><a href='/src/ReverseMarkdown.Test/Snippets.cs#L28-L44' title='Snippet source file'>snippet source</a> | <a href='#snippet-UsageWithConfig' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
+If you need to preserve markdown-like text as literal content (for example `# Heading` or `- Item`), either enable `EscapeMarkdownLineStarts` or use `CommonMark`:
+
+```cs
+var config = new ReverseMarkdown.Config
+{
+    EscapeMarkdownLineStarts = true
+    // or CommonMark = true
+};
+
+var converter = new ReverseMarkdown.Converter(config);
+```
+
 ## Configuration options
 
 * `DefaultCodeBlockLanguage` - Option to set the default code block language for Github style markdown if class based language markers are not available
@@ -94,6 +106,9 @@ var converter = new ReverseMarkdown.Converter(config);
 * `CommonMarkUseHtmlInlineTags` - When CommonMark is enabled, emit HTML for inline tags (`em`, `strong`, `a`, `img`) to avoid delimiter edge cases. Default is true
 * `CommonMarkIntrawordEmphasisSpacing` - When CommonMark is enabled, insert spaces to avoid intraword emphasis. Default is false
   * Note: CommonMark is best used on its own. Combining `CommonMark` with `GithubFlavored` can produce mixed output; keep them separate unless you explicitly want that behavior.
+* `EscapeMarkdownLineStarts` - Escape markdown line starts (headings, lists, block markers) in plain text output. Default is false
+  * Note: If you need to preserve markdown-like text as literal content, enable `EscapeMarkdownLineStarts` or use `CommonMark`.
+* `OutputLineEnding` - Output line endings used in generated markdown. Default is `Environment.NewLine`
 * `CleanupUnnecessarySpaces` - Cleanup unnecessary spaces in the output. Default is true
 * `SuppressDivNewlines` - Removes prefixed newlines from `div` tags. Default is false
 * `ListBulletChar` - Allows you to change the bullet character. Default value is `-`. Some systems expect the bullet character to be `*` rather than `-`, this config allows you to change it. Note: This option is ignored when `SlackFlavored` is enabled

--- a/src/ReverseMarkdown.Test/ConverterTests.cs
+++ b/src/ReverseMarkdown.Test/ConverterTests.cs
@@ -117,6 +117,22 @@ namespace ReverseMarkdown.Test
             Assert.Equal(@"1\. Point 1", converter.Convert("<p>1. Point 1</p>"));
         }
 
+        [Fact]
+        public void WhenOutputLineEndingConfigured_ThenNormalizeOutputLineEndings()
+        {
+            var html = "<p>one</p>\r\n<p>two</p>\r<p>three</p>\n<p>four</p>";
+            var config = new Config
+            {
+                OutputLineEnding = "\n"
+            };
+            var converter = new Converter(config);
+
+            var result = converter.Convert(html);
+
+            Assert.Equal(result, result.ReplaceLineEndings("\n"));
+            Assert.DoesNotContain("\r", result);
+        }
+
         
 
         

--- a/src/ReverseMarkdown/Config.cs
+++ b/src/ReverseMarkdown/Config.cs
@@ -31,6 +31,12 @@ namespace ReverseMarkdown
         /// </summary>
         public bool EscapeMarkdownLineStarts { get; set; } = false;
 
+        /// <summary>
+        /// Output line endings to use for the generated markdown.
+        /// Defaults to <see cref="Environment.NewLine" />.
+        /// </summary>
+        public string OutputLineEnding { get; set; } = Environment.NewLine;
+
         public bool SuppressDivNewlines { get; set; } = false;
 
         public bool RemoveComments { get; set; } = false;

--- a/src/ReverseMarkdown/Converter.cs
+++ b/src/ReverseMarkdown/Converter.cs
@@ -96,8 +96,10 @@ namespace ReverseMarkdown {
         {
             using var _ = EnsureContext();
 
+            html = html.ReplaceLineEndings("\n");
+
             if (Config.CommonMark && LooksLikeCommonMarkHtmlBlock(html)) {
-                return html;
+                return ApplyOutputLineEndings(html);
             }
 
             if (Config.CommonMark) {
@@ -105,7 +107,7 @@ namespace ReverseMarkdown {
                 if (trimmed.StartsWith("</", StringComparison.Ordinal) ||
                     html.Contains("<!--", StringComparison.Ordinal) ||
                     html.Contains("<![CDATA[", StringComparison.Ordinal)) {
-                    return html;
+                    return ApplyOutputLineEndings(html);
                 }
 
                 var paragraphTrimmed = html.Trim();
@@ -113,7 +115,7 @@ namespace ReverseMarkdown {
                     paragraphTrimmed.EndsWith("</p>", StringComparison.OrdinalIgnoreCase)) {
                     var inner = paragraphTrimmed.Substring(3, paragraphTrimmed.Length - 7);
                     if (inner.TrimStart().StartsWith("</", StringComparison.Ordinal)) {
-                        return inner;
+                        return ApplyOutputLineEndings(inner);
                     }
                 }
             }
@@ -146,16 +148,24 @@ namespace ReverseMarkdown {
             }
 
             if (!Config.CleanupUnnecessarySpaces) {
-                return result;
+                return ApplyOutputLineEndings(result);
             }
 
             if (Config.CommonMark) {
                 result = result.TrimEnd();
                 result = result.TrimStart('\r', '\n');
-                return result;
+                return ApplyOutputLineEndings(result);
             }
 
-            return result.Trim().FixMultipleNewlines();
+            return ApplyOutputLineEndings(result.Trim().FixMultipleNewlines());
+        }
+
+        private string ApplyOutputLineEndings(string content)
+        {
+            var lineEnding = string.IsNullOrEmpty(Config.OutputLineEnding)
+                ? Environment.NewLine
+                : Config.OutputLineEnding;
+            return content.ReplaceLineEndings(lineEnding);
         }
 
         private static bool LooksLikeCommonMarkHtmlBlock(string html)


### PR DESCRIPTION
- Normalize HTML input to \n before parsing for consistent conversion.
- Add Config.OutputLineEnding to control output newlines (defaults to Environment.NewLine).
- Apply output line ending normalization across all return paths.
- Add test for output line ending normalization with mixed CR/LF input.
- Document OutputLineEnding in README.

Fixes GH-23