### PR TITLE
Trim and Native AOT compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,3 +47,28 @@ jobs:
       # Run the test suite across every test target framework (net8.0/net9.0/net10.0).
       - name: Run tests
         run: dotnet test src/ReverseMarkdown.Test/ReverseMarkdown.Test.csproj -c Release
+
+  # Prove the library stays trim/Native-AOT compatible: publish a small app with PublishAot,
+  # fail on any trim (IL2xxx) or AOT (IL3xxx) warning, then run the native binary.
+  aot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v5
+      - name: Install .NET SDK (10)
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+      - name: Install Native AOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+      - name: AOT publish (fail on trim/AOT warnings)
+        run: |
+          set -o pipefail
+          dotnet publish tools/ReverseMarkdown.AotSmoke/ReverseMarkdown.AotSmoke.csproj \
+            -c Release -r linux-x64 2>&1 | tee aot.log
+          if grep -Eq "warning IL[23][0-9]{3}" aot.log; then
+            echo "::error::Trim/AOT (IL2xxx/IL3xxx) warnings found - library is not AOT-clean."
+            exit 1
+          fi
+      - name: Run the Native AOT binary
+        run: ./tools/ReverseMarkdown.AotSmoke/bin/Release/net10.0/linux-x64/native/ReverseMarkdown.AotSmoke

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ BenchmarkDotNet.Artifacts/
 
 # Local combined docs preview (scripts/preview-docs.sh)
 _preview/
+
+# Marketing drafts (not part of the library)
+marketing/

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ var converter = new ReverseMarkdown.Converter(config);
 - **Extensible** - custom readers (`IMdReader` + `[MarkdownReader]`), tag aliases, and a `Parse`/`Render` Markdown DOM for direct transformation.
 - **Tables, links, and images** - nested tables and captions, smart href handling, URI-scheme whitelisting, and base64 image handling (include / skip / save to disk).
 - **Broad framework support** - targets `netstandard2.0`, `net8.0`, `net9.0`, and `net10.0` (runs on .NET Framework 4.6.1+, .NET Core 2.0+, Mono, and Unity).
+- **Trimming and Native AOT ready** - the default conversion path uses no reflection; add custom readers with `RegisterReader` under trimming/AOT. See [Supported Frameworks](https://mysticmind.github.io/reversemarkdown-net/guide/supported-frameworks#trimming-and-native-aot).
 
 ## Performance
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -19,6 +19,27 @@ Register it by passing the assembly to the converter:
 
 snippet: sample_custom_reader_wire
 
+### Trimming and Native AOT
+
+ReverseMarkdown is trim- and [Native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/)-compatible.
+The default conversion path uses no reflection.
+
+The `[MarkdownReader]` + assembly form above discovers readers by **scanning assemblies with
+reflection**, which the trimmer can remove and Native AOT cannot analyze. Those overloads are marked
+`[RequiresUnreferencedCode]` / `[RequiresDynamicCode]`, so the analyzer will warn if you use them in
+a trimmed/AOT app.
+
+Under trimming or AOT, register readers **explicitly** instead - no attribute, no assembly, no
+reflection:
+
+```cs
+var converter = new ReverseMarkdown.Converter();
+converter.RegisterReader("mark", new HighlightReader());
+```
+
+`RegisterReader` overrides the built-in reader for that tag, exactly like the scanned form. Call it
+before converting; it is not safe to call concurrently with a conversion.
+
 ### Recipe: convert only a whitelist of tags, rest as plain text
 
 Register a reader that reads an element's children (which strips the tag but keeps its text) for

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -20,6 +20,8 @@ MultiMarkdown and Pandoc output flavors.
   the DOM directly.
 - **Fast and lean** - roughly 2–2.6× faster than v5 with ~2.7× less allocation; see
   [Performance](/guide/performance).
+- **Trimming and Native AOT ready** - the default path uses no reflection; see
+  [Supported Frameworks](/guide/supported-frameworks#trimming-and-native-aot).
 - **Broad framework support** - see [Supported Frameworks](/guide/supported-frameworks).
 
 Using v5.x? See the [v5.x documentation](https://github.com/mysticmind/reversemarkdown-net/blob/5.x/README.md).

--- a/docs/guide/supported-frameworks.md
+++ b/docs/guide/supported-frameworks.md
@@ -18,3 +18,30 @@ in addition to modern .NET (8/9/10).
 
 On `netstandard2.0`, the library uses the source-only [Polyfill](https://www.nuget.org/packages/Polyfill/)
 package (no runtime dependency) so modern BCL/LINQ/Regex APIs compile on the older target.
+
+## Trimming and Native AOT
+
+ReverseMarkdown is compatible with [trimming](https://learn.microsoft.com/dotnet/core/deploying/trimming/)
+and [Native AOT](https://learn.microsoft.com/dotnet/core/deploying/native-aot/) on the modern
+targets (`net8.0`+). The library is marked `IsAotCompatible`, and its CI publishes a Native AOT app
+on every change and fails on any trim (`IL2xxx`) or AOT (`IL3xxx`) warning.
+
+The **default conversion path uses no reflection**, so `new Converter().Convert(html)` is trim/AOT
+safe out of the box.
+
+The one reflection-based feature is the `[MarkdownReader]` + assembly-scanning form of
+[custom readers](/extending#custom-readers): those constructor overloads are annotated
+`[RequiresUnreferencedCode]` / `[RequiresDynamicCode]` and will produce analyzer warnings under
+trimming/AOT. Register readers explicitly instead - no reflection:
+
+```cs
+var converter = new ReverseMarkdown.Converter();
+converter.RegisterReader("mark", new HighlightReader());
+```
+
+See [Trimming and Native AOT](/extending#trimming-and-native-aot) in the extending guide for details.
+
+::: tip netstandard2.0
+`netstandard2.0` is not a Native AOT target, so `IsAotCompatible` is not applied there. AOT is a
+`net8.0`+ concern.
+:::

--- a/src/ReverseMarkdown.Test/CustomReaderTests.cs
+++ b/src/ReverseMarkdown.Test/CustomReaderTests.cs
@@ -38,5 +38,26 @@ namespace ReverseMarkdown.Test
             var md = converter.Render(converter.Parse("<p>a <mark>b</mark> c</p>"));
             Assert.Equal("a <mark>b</mark> c", Norm(md));
         }
+
+        [Fact]
+        public void Custom_reader_can_be_registered_explicitly_without_scanning()
+        {
+            // Trimming/AOT-safe path: no assembly scanning, no [MarkdownReader] discovery.
+            var converter = new Converter(new Config());
+            converter.RegisterReader("mark", new HighlightReader());
+
+            var md = converter.Render(converter.Parse("<p>a <mark>b</mark> c</p>"));
+            Assert.Equal("a ==b== c", Norm(md));
+        }
+
+        [Fact]
+        public void RegisterReader_overrides_a_built_in_reader()
+        {
+            var converter = new Converter(new Config());
+            converter.RegisterReader("b", new HighlightReader());
+
+            var md = converter.Render(converter.Parse("<p>a <b>b</b> c</p>"));
+            Assert.Equal("a ==b== c", Norm(md));
+        }
     }
 }

--- a/src/ReverseMarkdown/Converter.cs
+++ b/src/ReverseMarkdown/Converter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -22,17 +23,31 @@ namespace ReverseMarkdown {
         {
         }
 
-        public Converter(Config config) : this(config, null)
+        // Trimming/AOT-safe: uses the built-in readers only. Add custom readers with RegisterReader.
+        public Converter(Config config)
         {
+            Config = config;
+            _markdownDomReader = new MarkdownDomReader(config);
         }
 
+        [RequiresUnreferencedCode("Scans the given assemblies for [MarkdownReader] reader types via reflection; those types may be removed by the trimmer. Use RegisterReader to add custom readers under trimming/AOT.")]
+        [RequiresDynamicCode("Instantiates discovered reader types via Activator.CreateInstance.")]
         public Converter(Config config, params Assembly[]? additionalAssemblies)
         {
             Config = config;
-            _markdownDomReader = new MarkdownDomReader(Config, additionalAssemblies);
+            _markdownDomReader = additionalAssemblies is { Length: > 0 }
+                ? new MarkdownDomReader(config, additionalAssemblies)
+                : new MarkdownDomReader(config);
         }
 
         public Config Config { get; protected set; }
+
+        /// <summary>
+        /// Registers a custom <see cref="IMdReader"/> for a tag, overriding any built-in reader for
+        /// that tag. This is the trimming/Native-AOT-safe way to add custom readers (no assembly
+        /// scanning). Call before converting; not safe to call concurrently with conversion.
+        /// </summary>
+        public void RegisterReader(string tag, IMdReader reader) => _markdownDomReader.Register(tag, reader);
 
         /// <summary>The flavor used to render. The legacy boolean switches map into
         /// <see cref="Config.Flavor"/>, so it is the single source of truth.</summary>

--- a/src/ReverseMarkdown/Readers/MarkdownDomReader.cs
+++ b/src/ReverseMarkdown/Readers/MarkdownDomReader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -20,10 +21,16 @@ namespace ReverseMarkdown.Readers
         private readonly Dictionary<string, IMdReader> _readers = new(StringComparer.OrdinalIgnoreCase);
         private readonly Config _config;
 
-        public MarkdownDomReader(Config config) : this(config, null)
+        // Trimming/AOT-safe: registers only the built-in readers, no reflection. Add custom
+        // readers with <see cref="Register"/>.
+        public MarkdownDomReader(Config config)
         {
+            _config = config;
+            RegisterDefaults();
         }
 
+        [RequiresUnreferencedCode("Scans the given assemblies for [MarkdownReader] reader types via reflection; those types may be removed by the trimmer. Register custom readers explicitly with Register instead.")]
+        [RequiresDynamicCode("Instantiates discovered reader types via Activator.CreateInstance.")]
         public MarkdownDomReader(Config config, params Assembly[]? additionalAssemblies)
         {
             _config = config;
@@ -37,6 +44,8 @@ namespace ReverseMarkdown.Readers
             }
         }
 
+        [RequiresUnreferencedCode("Scans assemblies for [MarkdownReader] reader types via reflection.")]
+        [RequiresDynamicCode("Instantiates discovered reader types via Activator.CreateInstance.")]
         private void RegisterFromAssemblies(IEnumerable<Assembly> assemblies)
         {
             foreach (var assembly in assemblies)

--- a/src/ReverseMarkdown/ReverseMarkdown.csproj
+++ b/src/ReverseMarkdown/ReverseMarkdown.csproj
@@ -6,6 +6,12 @@
     <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <!-- Trim/Native AOT friendly. IsAotCompatible turns on the trim, single-file and AOT
+         analyzers (and implies IsTrimmable). Not supported on netstandard2.0, which is not
+         an AOT target anyway. The only reflection path (assembly-scanning reader discovery)
+         is annotated [RequiresUnreferencedCode]/[RequiresDynamicCode]; the default path and
+         Converter.RegisterReader are AOT-safe. -->
+    <IsAotCompatible Condition="!$(TargetFramework.StartsWith('netstandard'))">true</IsAotCompatible>
     <PackageProjectUrl>https://github.com/mysticmind/reversemarkdown-net</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>htmltomarkdown;html2markdown;converthtml;htmlconverter;html;converter;markdown</PackageTags>

--- a/src/ReverseMarkdown/ReverseMarkdown.csproj
+++ b/src/ReverseMarkdown/ReverseMarkdown.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>ReverseMarkdown is a Html to Markdown converter library in c#</Description>
-    <VersionPrefix>6.0.0</VersionPrefix>
+    <VersionPrefix>6.1.0</VersionPrefix>
     <Authors>Babu Annamalai</Authors>
     <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>

--- a/tools/ReverseMarkdown.AotSmoke/Program.cs
+++ b/tools/ReverseMarkdown.AotSmoke/Program.cs
@@ -1,0 +1,47 @@
+// Native AOT smoke test: published with PublishAot=true to prove ReverseMarkdown converts
+// correctly in a trimmed, ahead-of-time-compiled app (no reflection fallout, AngleSharp included).
+// Exits non-zero if the output is wrong, so CI fails on a regression.
+using ReverseMarkdown;
+using ReverseMarkdown.Dom;
+using ReverseMarkdown.Readers;
+
+var converter = new Converter(new Config { GithubFlavored = true });
+
+// Exercise the AOT-safe custom-reader API (no assembly scanning).
+converter.RegisterReader("mark", new HighlightReader());
+
+const string html = """
+    <h1>Title</h1>
+    <p>Hello <strong>AOT</strong> from <a href="http://x.com">link</a> <mark>hi</mark></p>
+    <ul><li>one</li><li>two</li></ul>
+    """;
+
+var md = converter.Convert(html);
+Console.WriteLine(md);
+
+var ok =
+    md.Contains("# Title") &&
+    md.Contains("**AOT**") &&
+    md.Contains("[link](http://x.com)") &&
+    md.Contains("==hi==") &&
+    md.Contains("- one");
+
+if (!ok)
+{
+    Console.Error.WriteLine("AOT smoke FAILED: unexpected conversion output.");
+    return 1;
+}
+
+Console.WriteLine("AOT smoke OK");
+return 0;
+
+// A custom reader registered explicitly (trim/AOT-safe path).
+sealed class HighlightReader : IMdReader
+{
+    public void Read(AngleSharp.Dom.IElement element, ReaderContext ctx)
+    {
+        ctx.Emit(new MdRawInline("==") { SourceTag = element.LocalName });
+        ctx.ReadChildren(element);
+        ctx.Emit(new MdRawInline("==") { SourceTag = element.LocalName });
+    }
+}

--- a/tools/ReverseMarkdown.AotSmoke/ReverseMarkdown.AotSmoke.csproj
+++ b/tools/ReverseMarkdown.AotSmoke/ReverseMarkdown.AotSmoke.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- Publish this app with Native AOT to prove the library is trim/AOT-safe. -->
+    <PublishAot>true</PublishAot>
+    <!-- Report every trim/AOT warning individually rather than collapsing to one. -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Pin to the net10.0 target: the library also targets netstandard2.0, which cannot be
+         AOT-compiled (NETSDK1207). The pin keeps the AOT publish to a single, valid TFM. -->
+    <ProjectReference Include="..\..\src\ReverseMarkdown\ReverseMarkdown.csproj"
+                      SetTargetFramework="TargetFramework=net10.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Makes ReverseMarkdown trim- and Native AOT-safe.

## Changes
- Enable `IsAotCompatible` on net8/9/10 (netstandard2.0 excluded).
- Keep the default conversion path reflection-free; annotate the only reflection path (`[MarkdownReader]` assembly scanning) with `[RequiresUnreferencedCode]` / `[RequiresDynamicCode]`.
- Add `Converter.RegisterReader(tag, reader)` - an AOT-safe way to add custom readers, no scanning.
- Add an AOT smoke app + CI job that fails on any trim/AOT warning.
- Document trimming/AOT in the README and docs.
- Bump version to 6.1.0.